### PR TITLE
2.0.0-alpha8

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0-alpha8]
+
+### Changed
+- Default matcher now supports IDs ending with a letter (IBW-###z, KTRA-###e)
+- Logging messages updated to be more consistent
+
+### Fixed
+
+- Jav321 scraper not running properly
+- Javinizer now properly uses the thumb csv when a custom path is set in `location.thumbcsv`
+- Error thrown when scraped genres are null and ignored genres are present
+
+
 ## [2.0.0-alpha7]
 
 ### Added
@@ -21,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Actresses being matched incorrectly due to false positives with FirstName/LastName matching
-- Dmm match when searching for IDs ending with a letter (IBW-###z, KTRA-###e, etc)
+- Dmm match when searching for IDs ending with a letter (IBW-###z, KTRA-###e)
 - Error being thrown when trying to trim a null translated description
 - Actress names containing backslash `\` in R18 fixed
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Choose one of the methods below:
 - Install the module directly from [PowerShell Gallery](https://www.powershellgallery.com/packages/Javinizer/) using PowerShell 6/7
 ```powershell
 # Install the module from PowerShell gallery (This will install the latest version by default)
-# Add -AllowPrelease to download a preview build
+# Add -AllowPrerelease to download a preview build
 PS> Install-Module Javinizer
 
 # Update the module to the newest version from PowerShell gallery
-# Add -AllowPrelease to download a preview build
+# Add -AllowPrerelease to download a preview build
 PS> Update-Module Javinizer
 ```
 

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -130,7 +130,7 @@
             ReleaseNotes             = 'https://github.com/jvlflame/Javinizer/blob/master/.github/CHANGELOG.md'
 
             # Prerelease string of this module
-            Prerelease               = 'alpha7'
+            Prerelease               = 'alpha8'
 
             # Flag to indicate whether the module requires explicit user acceptance for install/update/save
             RequireLicenseAcceptance = $false

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -167,8 +167,8 @@ function Convert-JVTitle {
         for ($x = 0; $x -lt $fileBaseNameUpper.Length; $x++) {
             $filePartNumber = $null
             #Match ID-###A, ID###B, etc.
-            if ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}[a-dA-D]") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            if ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[a-dA-D]") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 if ($fileP3 -eq 'A') { $filePartNumber = '1' }
                 elseif ($fileP3 -eq 'B') { $filePartNumber = '2' }
@@ -181,8 +181,8 @@ function Convert-JVTitle {
                 #elseif ($fileP3 -eq 'I') { $filePartNumber = '9' }
             }
             # Match ID-###-A, ID-###-B, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}[-][a-dA-D]") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-][a-dA-D]") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $fileP3 = $fileP3 -replace '-', ''
                 if ($fileP3 -eq 'A') { $filePartNumber = '1' }
@@ -204,57 +204,57 @@ function Convert-JVTitle {
                 }
                 #>
             # Match ID-###-1, ID-###-2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}[-]\d$") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]\d$") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $filePartNum = ($fileP3 -replace '-', '')[1]
                 $filePartNumber = $filePartNum
             }
             # Match ID-###-01, ID-###-02, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}[-]0\d$") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]0\d$") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $filePartNum = (($fileP3 -replace '-', '') -replace '0', '')[1]
                 $filePartNumber = $filePartNum
             }
             # Match ID-###-001, ID-###-002, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}[-]00\d$") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]00\d$") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $filePartNum = (($fileP3 -replace '-', '') -replace '0', '')[1]
                 $filePartNumber = $filePartNum
             }
             # Match ID-### - pt1, ID-### - pt2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6} [-] pt|PT") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E? [-] pt|PT") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'pt', '')[1]
                 $filePartNumber = $filePartNum
             }
             # Match ID-### - part1, ID ### - part2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6} [-] part|PART") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E? [-] part|PART") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'pt', '')[1]
                 $filePartNumber = $filePartNum
             }
             # Match ID-###-pt1, ID-###-pt2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}[-]pt|PT") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]pt|PT") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'pt', '')[1]
                 $filePartNumber = $filePartNum
             }
             # Match ID-###-part1, ID-###-part2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}[-]part|PART") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]part|PART") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'pt', '')[1]
                 $filePartNumber = $filePartNum
             }
             # Match ID-###-cd1, ID-###-cd2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}[-]cd|CD") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]cd|CD") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + $fileP2
                 $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'cd', '')[1]
                 $filePartNumber = $filePartNum
@@ -263,7 +263,11 @@ function Convert-JVTitle {
             # Match everything else
             else {
                 $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
+                if ($fileP3 -match '^Z' -or $fileP3 -match '^E') {
+                    $fileBaseNameUpperCleaned += $fileP1 + $fileP2 + $fileP3
+                } else {
+                    $fileBaseNameUpperCleaned += $fileP1 + $fileP2
+                }
             }
             <#             if ($fileBaseNameUpper[$x] -match '([a-zA-Z|tT28]+-\d+z{0,1}Z{0,1}e{0,1}E{0,1})') {
                 $movieId = $fileBaseNameUpper[$x]
@@ -278,7 +282,12 @@ function Convert-JVTitle {
             if ($fileBaseNameUpper[$x] -match '(([a-zA-Z|tT28|rR18]+)-(\d+z{0,1}Z{0,1}e{0,1}E{0,1}))') {
                 $movieId = $fileBaseNameUpperCleaned[$x]
                 $splitId = $fileBaseNameUpperCleaned[$x] -split '-'
-                $contentId = $splitId[0] + $splitId[1].PadLeft(5, '0')
+                if (($splitId[1])[-1] -match '\D') {
+                    $appendChar = ($splitId[1])[-1]
+                    $splitId[1] = $splitId[1] -replace '\D', ''
+                }
+                $contentId = $splitId[0] + $splitId[1].PadLeft(5, '0') + $appendChar
+                $contentId = $contentId.Trim()
             } else {
                 $movieId = ($fileBaseNameUpperCleaned[$x] -split '\d', 3 | Where-Object { $_ -ne '' }) -join '-'
                 $contentId = $fileBaseNameUpperCleaned[$x]

--- a/src/Javinizer/Public/Get-DmmData.ps1
+++ b/src/Javinizer/Public/Get-DmmData.ps1
@@ -12,10 +12,10 @@ function Get-DmmData {
         $dmmUrl = $Url
 
         try {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "Performing [GET] on URL [$dmmUrl]"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$dmmUrl]"
             $webRequest = Invoke-WebRequest -Uri $dmmUrl -Method Get -Verbose:$false
         } catch {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "Error [GET] on URL [$dmmUrl]: $PSItem"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Error [GET] on URL [$dmmUrl]: $PSItem"
         }
 
         $movieDataObject = [PSCustomObject]@{
@@ -39,7 +39,7 @@ function Get-DmmData {
             #TrailerUrl    = Get-DmmTrailerUrl -WebRequest $webRequest
         }
 
-        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "DMM data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
+        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] DMM data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
         Write-Output $movieDataObject
     }
 }

--- a/src/Javinizer/Public/Get-DmmUrl.ps1
+++ b/src/Javinizer/Public/Get-DmmUrl.ps1
@@ -22,9 +22,7 @@ function Get-DmmUrl {
                 $splitId = $Id -split '-'
                 if (($splitId[1])[-1] -match '\D') {
                     $appendChar = ($splitId[1])[-1]
-                    Write-Debug $appendChar
                     $splitId[1] = $splitId[1] -replace '\D', ''
-                    Write-Debug $splitId[1]
                 }
                 $Id = $splitId[0] + $splitId[1].PadLeft(5, '0') + $appendChar
                 $Id = $Id.Trim()

--- a/src/Javinizer/Public/Get-DmmUrl.ps1
+++ b/src/Javinizer/Public/Get-DmmUrl.ps1
@@ -11,10 +11,11 @@ function Get-DmmUrl {
     )
 
     process {
+        $originalId = $Id
         if ($r18Url) {
             $r18Id = (($r18Url -split 'id=')[1] -split '\/')[0]
             $directUrl = "https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=$r18Id"
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "Converting R18 Id to Dmm: [$r18Id] -> [$directUrl]"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] Converting R18 Id to Dmm: [$r18Id] -> [$directUrl]"
         } else {
             # Convert the movie Id (ID-###) to content Id (ID00###) to match dmm naming standards
             if ($Id -match '([a-zA-Z|tT28|rR18]+-\d+z{0,1}Z{0,1}e{0,1}E{0,1})') {
@@ -32,10 +33,10 @@ function Get-DmmUrl {
             $searchUrl = "https://www.dmm.co.jp/search/?redirect=1&enc=UTF-8&category=&searchstr=$Id"
 
             try {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$searchUrl]"
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$searchUrl]"
                 $webRequest = Invoke-WebRequest -Uri $searchUrl -Method Get -Verbose:$false
             } catch {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Error occurred on [GET] on URL [$searchUrl]: $PSItem"
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] Error occurred on [GET] on URL [$searchUrl]: $PSItem"
             }
 
             $retryCount = 3
@@ -47,19 +48,19 @@ function Get-DmmUrl {
             }
 
             if ($numResults -ge 1) {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Searching [$retryCount] of [$numResults] results for [$Id]"
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] Searching [$retryCount] of [$numResults] results for [$originalId]"
 
                 $count = 1
                 foreach ($result in $searchResults) {
                     try {
-                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$result]"
+                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$result]"
                         $webRequest = Invoke-WebRequest -Uri $result -Method Get -Verbose:$false
                     } catch {
-                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Error occurred on [GET] on URL [$result]: $PSItem"
+                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] Error occurred on [GET] on URL [$result]: $PSItem"
                     }
 
                     $resultId = Get-DmmContentId -WebRequest $webRequest
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Result [$count] is [$resultId]"
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] Result [$count] is [$resultId]"
                     if ($resultId -match "^(.*_)?\d*$Id") {
                         $directUrl = $result
                         break
@@ -75,7 +76,7 @@ function Get-DmmUrl {
         }
 
         if ($null -eq $directUrl) {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] not matched on DMM"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] not matched on DMM"
             return
         } else {
             $urlObject = [PSCustomObject]@{

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -454,7 +454,7 @@ function Get-JVAggregatedData {
                 }
 
             } else {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($Data[0].Id)] Translation language is missing"
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] Translation language is missing"
             }
         }
 

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -162,7 +162,7 @@ function Get-JVAggregatedData {
                 $GenreCsvPath = $Settings.'location.genrecsv'
             }
             if ($Settings.'location.thumbcsv' -ne '') {
-                $ThumbCsvPath = $Settings.'location.genrecsv'
+                $ThumbCsvPath = $Settings.'location.thumbcsv'
             }
         }
 

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -384,8 +384,6 @@ function Get-JVAggregatedData {
                     $matched = @()
                     $matchedActress = @()
 
-                    # Try three methods for matching aliases
-                    # FirstName | FirstName, LastName | JapaneseName
                     if (($aggregatedDataObject.Actress[$x].JapaneseName -ne '') -and ($matched = Compare-Object -ReferenceObject $actressCsv -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('JapaneseName'))) {
                         if ($matched.Count -eq 1) {
                             $matchedActress = $matched
@@ -434,9 +432,12 @@ function Get-JVAggregatedData {
         if ($IgnoreGenre) {
             $originalGenres = $aggregatedDataObject.Genre
             $ignoredGenres = $IgnoreGenre -join '|'
-            $aggregatedDataObject.Genre = $aggregatedDataObject.Genre | Where-Object { $_ -notmatch $ignoredGenres }
-            foreach ($ignored in (Compare-Object -ReferenceObject $originalGenres -DifferenceObject $aggregatedDataObject.Genre)) {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Genre - $($ignored.InputObject)] ignored"
+            $aggregatedDataObject.Genre = $aggregatedDataObject.Genre | Where-Object { $_ -notmatch $ignoredGenres -and $_ -ne '' }
+            if ($null -ne $originalGenres -or $originalGenres -ne '') {
+                $differenceObject = (Compare-Object -ReferenceObject $originalGenres -DifferenceObject $aggregatedDataObject.Genre)
+                foreach ($ignored in $differenceObject) {
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Genre - $($ignored.InputObject)] ignored"
+                }
             }
         }
 

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -430,13 +430,14 @@ function Get-JVAggregatedData {
         }
 
         if ($IgnoreGenre) {
-            $originalGenres = $aggregatedDataObject.Genre
-            $ignoredGenres = $IgnoreGenre -join '|'
-            $aggregatedDataObject.Genre = $aggregatedDataObject.Genre | Where-Object { $_ -notmatch $ignoredGenres -and $_ -ne '' }
-            if ($null -ne $originalGenres -or $originalGenres -ne '') {
-                $differenceObject = (Compare-Object -ReferenceObject $originalGenres -DifferenceObject $aggregatedDataObject.Genre)
-                foreach ($ignored in $differenceObject) {
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Genre - $($ignored.InputObject)] ignored"
+            if ($aggregatedDataObject.Genre) {
+                $originalGenres = $aggregatedDataObject.Genre
+                $ignoredGenres = $IgnoreGenre -join '|'
+                $aggregatedDataObject.Genre = $aggregatedDataObject.Genre | Where-Object { $_ -notmatch $ignoredGenres -and $_ -ne '' }
+                $originalGenres | ForEach-Object {
+                    if ($aggregatedDataObject.Genre -notcontains $_) {
+                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Genre - $_] ignored"
+                    }
                 }
             }
         }

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -268,7 +268,7 @@ function Get-JVData {
             $jobName = @((Get-Job | Where-Object { $_.Name -like "jvdata-*" } | Select-Object Name).Name)
 
             if ($jobCount -eq 0) {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] No scrapers were run"
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] [$($MyInvocation.MyCommand.Name)] No scrapers were run"
                 return
             } else {
                 Write-Debug "[$Id] [$($MyInvocation.MyCommand.Name)] [Waiting - Scraper jobs] [$jobName]"

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -97,7 +97,7 @@ function Get-JVData {
             }
 
             if ($R18 -or $R18Zh) {
-                if (!($R18Url)) {
+                if (!($R18Url -or $R18ZhUrl)) {
                     $jvR18Url = Get-R18Url -Id $Id
                 }
                 if ($R18) {
@@ -133,7 +133,7 @@ function Get-JVData {
             }
 
             if ($Javlibrary -or $JavlibraryJa -or $JavlibraryZh) {
-                if (!($JavlibraryUrl)) {
+                if (!($JavlibraryUrl -or $JavlibraryJaUrl -or $JavlibraryZhUrl)) {
                     $jvJavlibraryUrl = Get-JavlibraryUrl -Id $Id -BaseUrl $JavlibraryBaseUrl
                 }
                 if ($Javlibrary) {
@@ -198,7 +198,7 @@ function Get-JVData {
             }
 
             if ($Javbus -or $JavbusJa -or $JavbusZh) {
-                if (!($JavbusUrl)) {
+                if (!($JavbusUrl -or $JavbusJaUrl -or $JavbusZhUrl)) {
                     $jvJavbusUrl = Get-JavbusUrl -Id $Id
                 }
                 if ($Javbus) {
@@ -258,7 +258,7 @@ function Get-JVData {
                         $using:Jav321JaUrl | Get-Jav321Data
                     } elseif ($using:jvJav321Url) {
                         $jvJav321Url = $using:jvJav321Url
-                        $jvJav321JaUrl.Ja | Get-Jav321Data
+                        $jvJav321Url.Ja | Get-Jav321Data
                     }
                 } | Out-Null
             }

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -251,7 +251,7 @@ function Get-JVData {
                 if (!($Jav321JaUrl)) {
                     $jvJav321Url = Get-Jav321Url -Id $Id
                 }
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] [Search - Jav321] [$Url - $Jav321Url]"
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] [Search - Jav321] [Url - $Jav321JaUrl]"
                 Start-ThreadJob  -Name "jvdata-Jav321" -ThrottleLimit 100 -ScriptBlock {
                     Import-Module $using:jvModulePath
                     if ($using:Jav321JaUrl) {

--- a/src/Javinizer/Public/Get-Jav321Data.ps1
+++ b/src/Javinizer/Public/Get-Jav321Data.ps1
@@ -11,10 +11,10 @@ function Get-Jav321Data {
         $movieDataObject = @()
 
         try {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "Performing [GET] on URL [$Url]"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$Url]"
             $webRequest = Invoke-RestMethod -Uri $Url -Verbose:$false
         } catch {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "Error [GET] on URL [$Url]: $PSItem"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Error [GET] on URL [$Url]: $PSItem"
         }
 
         $movieDataObject = [PSCustomObject]@{
@@ -34,7 +34,7 @@ function Get-Jav321Data {
             ScreenshotUrl = Get-Jav321ScreenshotUrl -WebRequest $webRequest
         }
 
-        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "Jav321 data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
+        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] Jav321 data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
         Write-Output $movieDataObject
     }
 }

--- a/src/Javinizer/Public/Get-Jav321Url.ps1
+++ b/src/Javinizer/Public/Get-Jav321Url.ps1
@@ -59,7 +59,7 @@ function Get-Jav321Url {
             }
 
             if ($null -eq $directUrl) {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] Search [$Id] not matched on Jav321"
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Search [$Id] not matched on Jav321"
                 return
             } else {
                 $urlObject = [PSCustomObject]@{
@@ -68,7 +68,7 @@ function Get-Jav321Url {
                 Write-Output $urlObject
             }
         } else {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] Search [$Id] not matched on Jav321"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Search [$Id] not matched on Jav321"
             return
         }
     }

--- a/src/Javinizer/Public/Get-JavbusData.ps1
+++ b/src/Javinizer/Public/Get-JavbusData.ps1
@@ -11,10 +11,10 @@ function Get-JavbusData {
         $movieDataObject = @()
 
         try {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "Performing [GET] on URL [$Url]"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$Url]"
             $webRequest = Invoke-RestMethod -Uri $Url -Verbose:$false
         } catch {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "Error [GET] on URL [$Url]: $PSItem"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Error [GET] on URL [$Url]: $PSItem"
         }
 
         $movieDataObject = [PSCustomObject]@{
@@ -35,7 +35,7 @@ function Get-JavbusData {
             ScreenshotUrl = Get-JavbusScreenshotUrl -WebRequest $webRequest
         }
 
-        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "JavBus data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
+        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] JavBus data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
         Write-Output $movieDataObject
     }
 }

--- a/src/Javinizer/Public/Get-JavbusUrl.ps1
+++ b/src/Javinizer/Public/Get-JavbusUrl.ps1
@@ -24,7 +24,7 @@ function Get-JavbusUrl {
                     Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$searchUrl]"
                     $webRequest = Invoke-RestMethod -Uri $searchUrl -Method Get -Verbose:$false
                 } catch {
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] not matched on JavBus"
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] [$($MyInvocation.MyCommand.Name)] not matched on JavBus"
                     return
                 }
             }
@@ -72,7 +72,7 @@ function Get-JavbusUrl {
             }
 
             if ($null -eq $directUrl) {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] not matched on JavBus"
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] [$($MyInvocation.MyCommand.Name)] not matched on JavBus"
                 return
             } else {
                 $urlObject = [PSCustomObject]@{

--- a/src/Javinizer/Public/Get-JavlibraryData.ps1
+++ b/src/Javinizer/Public/Get-JavlibraryData.ps1
@@ -11,10 +11,10 @@ function Get-JavlibraryData {
         $movieDataObject = @()
 
         try {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "Performing [GET] on URL [$Url] with Session: [$Session] and UserAgent: [$($Session.UserAgent)]"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$Url] with Session: [$Session] and UserAgent: [$($Session.UserAgent)]"
             $webRequest = Invoke-WebRequest -Uri $Url -Method Get -WebSession $Session -UserAgent $Session.UserAgent -Verbose:$false
         } catch {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "Error [GET] on URL [$Url]: $PSItem"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Error [GET] on URL [$Url]: $PSItem"
         }
 
         $movieDataObject = [PSCustomObject]@{
@@ -36,7 +36,7 @@ function Get-JavlibraryData {
             ScreenshotUrl = Get-JavlibraryScreenshotUrl -WebRequest $webRequest
         }
 
-        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "JAVLibrary data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
+        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] JAVLibrary data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
         Write-Output $movieDataObject
     }
 }

--- a/src/Javinizer/Public/Get-JavlibraryUrl.ps1
+++ b/src/Javinizer/Public/Get-JavlibraryUrl.ps1
@@ -83,7 +83,7 @@ function Get-JavlibraryUrl {
         }
 
         if ($null -eq $javlibraryUrl) {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] not matched on JavLibrary"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] [$($MyInvocation.MyCommand.Name)] not matched on JavLibrary"
             return
         } else {
             $javlibraryUrlJa = $javlibraryUrl -replace '/en/', '/ja/'

--- a/src/Javinizer/Public/Get-R18Data.ps1
+++ b/src/Javinizer/Public/Get-R18Data.ps1
@@ -80,10 +80,10 @@ function Get-R18Data {
         }
 
         try {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "Performing [GET] on URL [$Url]"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] Performing [GET] on URL [$Url]"
             $webRequest = Invoke-WebRequest -Uri $Url -Method Get -Verbose:$false
         } catch {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "Error [GET] on URL [$Url]: $PSItem"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Error [GET] on URL [$Url]: $PSItem"
         }
 
         $movieDataObject = [PSCustomObject]@{
@@ -107,7 +107,7 @@ function Get-R18Data {
             TrailerUrl    = Get-R18TrailerUrl -WebRequest $webRequest
         }
 
-        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "R18 data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
+        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] R18 data object: $($movieDataObject | ConvertTo-Json -Depth 32 -Compress)"
         Write-Output $movieDataObject
     }
 }

--- a/src/Javinizer/Public/Get-R18Url.ps1
+++ b/src/Javinizer/Public/Get-R18Url.ps1
@@ -138,7 +138,7 @@ function Get-R18Url {
         }
 
         if ($null -eq $directUrl) {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] not matched on R18"
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Id] [$($MyInvocation.MyCommand.Name)] not matched on R18"
             return
         } else {
             $directUrlZh = $directUrl + '&lg=zh'

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -595,13 +595,13 @@ function Javinizer {
                 }
 
                 if ($null -eq $javMovies) {
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "Exiting -- no valid movies detected in [$Path]"
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Path] Exiting -- no valid movies detected"
                     return
                 }
 
                 if ($Url) {
                     if (!(Test-Path -LiteralPath $Path -PathType Leaf)) {
-                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "Exited [$Path] is not a valid single file path"
+                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$Path] Exiting -- not a valid single file path"
                         return
                     }
 
@@ -635,11 +635,12 @@ function Javinizer {
                                 if ($javAggregatedData.NullFields -eq '') {
                                     $javAggregatedData | Set-JVMovie -Path $movie.FullName -DestinationPath $DestinationPath -Settings $Settings -PartNumber $movie.Partnumber -Force:$Force
                                 } else {
-                                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "Skipped [$($movie.FileName)] missing required fields [$($javAggregatedData.NullFields)]"
+                                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($movie.FileName)] Skipped -- missing required fields [$($javAggregatedData.NullFields)]"
                                     return
                                 }
                             } else {
-                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "Skipped [$($movie.FileName)] not matched"
+                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($movie.FileName)] Skipped -- not matched"
+                                return
                             }
                         }
                     }

--- a/src/Javinizer/Public/Set-JVEmbyThumbs.ps1
+++ b/src/Javinizer/Public/Set-JVEmbyThumbs.ps1
@@ -125,7 +125,7 @@ function Set-JVEmbyThumbs {
                         Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Error occurred on [POST] on URL [$primaryPostUrl]: $PSItem" -Action 'Continue'
                     }
 
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info -Message "Set [$($actress.Name)] => [$thumbUrl]"
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info -Message "[$($MyInvocation.MyCommand.Name)] Set [$($actress.Name)] => [$thumbUrl]"
                 }
             }
         }

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -424,12 +424,12 @@ function Set-JVMovie {
                         if ((Get-Item -LiteralPath $Path).FullName -ne $filePath) {
                             if (!(Test-Path -LiteralPath $filePath)) {
                                 Move-Item -LiteralPath $Path -Destination $filePath -Force:$Force
-                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info "Completed [$Path] => [$filePath]"
+                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Completed [$Path] => [$filePath]"
                             } else {
-                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "Completed [$Path] but did not move as the destination file already exists"
+                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Completed [$Path] but did not move as the destination file already exists"
                             }
                         } else {
-                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info "Updated [$Path]"
+                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Updated [$Path]"
                         }
                     }
                 } catch {
@@ -442,16 +442,16 @@ function Set-JVMovie {
                         if ((Get-Item -LiteralPath $Path).FullName -ne $filePath) {
                             if (!(Test-Path -LiteralPath $filePath)) {
                                 Move-Item -LiteralPath $Path -Destination $filePath -Force:$Force
-                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info "Completed [$Path] => [$filePath]"
+                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Completed [$Path] => [$filePath]"
                             } else {
-                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "Completed [$Path] but did not move as the destination file already exists"
+                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Completed [$Path] but did not move as the destination file already exists"
                             }
                         } else {
-                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info "Updated [$Path]"
+                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Updated [$Path]"
                         }
                     }
                 } catch {
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Error occurred when renaming and moving file [$Path] to [$filePath]: $PSItem"
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [$($MyInvocation.MyCommand.Name)] Error occurred when renaming and moving file [$Path] to [$filePath]: $PSItem"
                 }
             }
         }

--- a/src/Javinizer/Public/Update-JVThumbCsv.ps1
+++ b/src/Javinizer/Public/Update-JVThumbCsv.ps1
@@ -80,12 +80,12 @@ function Update-JVThumbCsv {
                     if ($null -ne $actressCsv) {
                         if (!(Compare-Object -ReferenceObject $actressCsv -DifferenceObject $actress -IncludeEqual -ExcludeDifferent -Property @('JapaneseName', 'ThumbUrl'))) {
                             $actressString = "$($actress.LastName) $($actress.FirstName)".Trim()
-                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info -Message "Wrote [$actressString - $($actress.JapaneseName)] [Page $x] to thumb csv"
+                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info -Message "[$($MyInvocation.MyCommand.Name)] Wrote [$actressString - $($actress.JapaneseName)] [Page $x] to thumb csv"
                             $actress | Export-Csv -LiteralPath $ThumbCsvPath -Append -Encoding utf8
                         }
                     } else {
                         $actressString = "$($actress.LastName) $($actress.FirstName)".Trim()
-                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info -Message "Wrote [$actressString - $($actress.JapaneseName)] [Page $x] to thumb csv"
+                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info -Message "[$($MyInvocation.MyCommand.Name)] Wrote [$actressString - $($actress.JapaneseName)] [Page $x] to thumb csv"
                         $actress | Export-Csv -LiteralPath $ThumbCsvPath -Append -Encoding utf8
                     }
                 }


### PR DESCRIPTION
### Changed
- Default matcher now supports IDs ending with a letter (IBW-###z, KTRA-###e)
- Logging messages updated to be more consistent

### Fixed

- Jav321 scraper not running properly
- Javinizer now properly uses the thumb csv when a custom path is set in `location.thumbcsv`
- Error thrown when scraped genres are null and ignored genres are present