### PR TITLE
2.0.2 - Extra

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,8 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Dmm/DmmJa scraper
     - Aliases are now removed from the Japanese actress name
-    - TrailerUrl no longer contains an invalid url
+    - TrailerUrl no longer contains an invalid url with duplicate "https"
     - Actresses are now fully scraped if there are 10+ actresses in a movie
+    - Maker, Series, and Label no longer pulls inaccurate data
+- Javbus scraper
+    - Search no longer fails when title html spans multiple lines
+    - Both Japanese and English actress names are now pulled when scraping an uncensored movie
+- Javinizer no longers fails to scrape when running in PowerShell 6
 
 ## [2.0.1]
 

--- a/src/Javinizer/Private/Scraper.Dmm.ps1
+++ b/src/Javinizer/Private/Scraper.Dmm.ps1
@@ -124,7 +124,7 @@ function Get-DmmMaker {
 
     process {
         try {
-            $maker = ($Webrequest.Content | Select-String -Pattern '\/article=maker\/id=\d*\/">(.*)<\/a>').Matches.Groups[1].Value
+            $maker = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|\/en\/mono\/dvd\/)-\/list\/=\/article=maker\/id=\d*\/">(.*)<\/a>').Matches.Groups[2].Value
         } catch {
             return
         }
@@ -140,7 +140,7 @@ function Get-DmmLabel {
 
     process {
         try {
-            $label = ($Webrequest.Content | Select-String -Pattern '\/article=label\/id=\d*\/">(.*)<\/a>').Matches.Groups[1].Value
+            $label = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|\/en\/mono\/dvd\/)-\/list\/=\/article=label\/id=\d*\/">(.*)<\/a>').Matches.Groups[2].Value
         } catch {
             return
         }
@@ -156,7 +156,7 @@ function Get-DmmSeries {
 
     process {
         try {
-            $series = ($Webrequest.Content | Select-String -Pattern '\/article=series\/id=\d*\/">(.*)<\/a>').Matches.Groups[1].Value
+            $series = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|\/en\/mono\/dvd\/)-\/list\/=\/article=series\/id=\d*\/">(.*)<\/a><\/td>').Matches.Groups[2].Value
         } catch {
             return
         }

--- a/src/Javinizer/Private/Scraper.Javbus.ps1
+++ b/src/Javinizer/Private/Scraper.Javbus.ps1
@@ -7,7 +7,7 @@ function Get-JavbusId {
     process {
         try {
             $id = ($Webrequest | ForEach-Object { $_ -split '\n' } |
-                Select-String '<title>(.*?) (.*?) - JavBus<\/title>').Matches.Groups[1].Value
+                Select-String '<title>(.*?) (.*?)').Matches.Groups[1].Value
         } catch {
             return
         }
@@ -25,9 +25,14 @@ function Get-JavbusTitle {
         try {
             $title = ($Webrequest | ForEach-Object { $_ -split '\n' } |
                 Select-String '<title>(.*?) (.*?) - JavBus<\/title>').Matches.Groups[2].Value
-
         } catch {
-            return
+            try {
+                $titleStart = ($Webrequest | ForEach-Object { $_ -split '\n' } | Select-String '<title>(.*?) (.*)').Matches.Groups[2].Value
+                $titleEnd = ($Webrequest | ForEach-Object { $_ -split '\n' } | Select-String '(.*?) - JavBus<\/title>').Matches.Groups[1].Value
+                $title = $titleStart + $titleEnd
+            } catch {
+                return
+            }
         }
 
         $title = Convert-HtmlCharacter -String $title
@@ -217,8 +222,14 @@ function Get-JavbusActress {
 
         foreach ($actress in $actresses) {
             $baseUrl = ($actress.Groups[1].Value) -replace '/ja', '' -replace '/en', ''
-            $engActressUrl = "$baseUrl/en/star/$($actress.Groups[2].Value)"
-            $jaActressUrl = "$baseUrl/ja/star/$($actress.Groups[2].Value)"
+            if ($baseUrl -match '/uncensored') {
+                $engActressUrl = "https://www.javbus.com/en/uncensored/star/$($actress.Groups[2].Value)"
+                $jaActressUrl = "https://www.javbus.com/ja/uncensored/star/$($actress.Groups[2].Value)"
+            } else {
+                $engActressUrl = "$baseUrl/en/star/$($actress.Groups[2].Value)"
+                $jaActressUrl = "$baseUrl/ja/star/$($actress.Groups[2].Value)"
+            }
+
             $actressName = $actress.Groups[4].Value
             $thumbUrl = $actress.Groups[3].Value
             if ($thumbUrl -like '*nowprinting*' -or $thumbUrl -like '*now_printing*') {


### PR DESCRIPTION
- Dmm/DmmJa scraper
    - Maker, Series, and Label no longer pulls inaccurate data
- Javbus scraper
    - Search no longer fails when title html spans multiple lines
    - Both Japanese and English actress names are now pulled when scraping an uncensored movie
- Javinizer no longers fails to scrape when running in PowerShell 6