### PR TITLE
[Fix][Enhancement] Improved Convert-JVTitle and fixed issues related to multi-part files.

### DIFF
--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -81,6 +81,11 @@ function Convert-JVTitle {
                 try {
                     $id = ($file | Select-String $RegexString).Matches.Groups[$RegexIdMatch].Value
                     $partNum = ($file | Select-String $RegexString).Matches.Groups[$RegexPtMatch].Value
+
+                    # If ID#### and there's no hypen, subsequent searches will fail
+                    if($id -match '^([a-z]+)(\d+)$') {
+                        $id = $Matches[1] + "-" + ($Matches[2] -replace '^0{1,5}', '').PadLeft(3, '0')
+                    }
                 } catch {
                     Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "File [$file] not matched by regex"
                     break
@@ -193,7 +198,7 @@ function Convert-JVTitle {
             # Match ID-### - cd1, ID-### - cd2, etc.
             elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?\s?[-]\s?(cd|part|pt)?[-]?\d{1,3}") {
                 $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?\s?[-])"
-                $fileBaseNameUpperCleaned += $fileP1 + "-" + ($fileP2 -replace '-', '').Trim()
+                $fileBaseNameUpperCleaned += $fileP1 + "-" + (($fileP2 -replace '-', '') -replace '0{1,5}', '').Trim().PadLeft(3, '0')
                 $filePartNum = ((($fileP3 -replace '-', '') -replace '^0{1,5}', '') -replace '(cd|part|pt)', '').Trim()
                 $filePartNumber = [int]$filePartNum
             }

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -145,6 +145,7 @@ function Convert-JVTitle {
                             # Write modified filename to $fileBaseNameHyphen, inserting a '-' at the specified
                             # index between the alphabetical and numerical character, and appending extension
                             $fileBaseNameHyphen = ($file.Insert($x + 1, '-'))
+                            break
                         }
                     }
                     # Get index if file changed
@@ -161,34 +162,17 @@ function Convert-JVTitle {
         # Clean any trailing text if not removed by $RemoveStrings
         for ($x = 0; $x -lt $fileBaseNameUpper.Length; $x++) {
             $filePartNumber = $null
-            #Match ID-###A, ID###B, etc.
-            if ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[a-dA-D]") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                if ($fileP3 -eq 'A') { $filePartNumber = '1' }
-                elseif ($fileP3 -eq 'B') { $filePartNumber = '2' }
-                elseif ($fileP3 -eq 'C') { $filePartNumber = '3' }
-                elseif ($fileP3 -eq 'D') { $filePartNumber = '4' }
-                #elseif ($fileP3 -eq 'E') { $filePartNumber = '5' }
-                #elseif ($fileP3 -eq 'F') { $filePartNumber = '6' }
-                #elseif ($fileP3 -eq 'G') { $filePartNumber = '7' }
-                #elseif ($fileP3 -eq 'H') { $filePartNumber = '8' }
-                #elseif ($fileP3 -eq 'I') { $filePartNumber = '9' }
-            }
+            # Match ID-###A, ID###B, etc.
             # Match ID-###-A, ID-###-B, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-][a-dA-D]") {
+            # Match ID-### - A, ID-### - B, etc.
+            if ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?\s?[-]?\s?[A-Z]$") {
                 $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $fileP3 = $fileP3 -replace '-', ''
-                if ($fileP3 -eq 'A') { $filePartNumber = '1' }
-                elseif ($fileP3 -eq 'B') { $filePartNumber = '2' }
-                elseif ($fileP3 -eq 'C') { $filePartNumber = '3' }
-                elseif ($fileP3 -eq 'D') { $filePartNumber = '4' }
-                #elseif ($fileP3 -eq 'E') { $filePartNumber = '5' }
-                #elseif ($fileP3 -eq 'F') { $filePartNumber = '6' }
-                #elseif ($fileP3 -eq 'G') { $filePartNumber = '7' }
-                #elseif ($fileP3 -eq 'H') { $filePartNumber = '8' }
-                #elseif ($fileP3 -eq 'I') { $filePartNumber = '9' }
+                $fileBaseNameUpperCleaned += $fileP1 + "-" + (($fileP2 -replace '-', '') -replace '^0{1,5}', '').PadLeft(3, '0')
+                $fileP3 = ($fileP3 -replace '-', '').Trim()
+                $asciiP3 = [int][char]$fileP3
+                if ($asciiP3 -gt 64 -and $asciiP3 -lt 91) {
+                    $filePartNumber = $asciiP3 - 64
+                }
             }
             <#
                 #Match ID-###-A, ID-###-B, etc.
@@ -199,60 +183,19 @@ function Convert-JVTitle {
                 }
                 #>
             # Match ID-###-1, ID-###-2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]\d$") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $filePartNum = ($fileP3 -replace '-', '')[1]
-                $filePartNumber = $filePartNum
-            }
             # Match ID-###-01, ID-###-02, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]0\d$") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $filePartNum = (($fileP3 -replace '-', '') -replace '0', '')[1]
-                $filePartNumber = $filePartNum
-            }
             # Match ID-###-001, ID-###-002, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]00\d$") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $filePartNum = (($fileP3 -replace '-', '') -replace '0', '')[1]
-                $filePartNumber = $filePartNum
-            }
-            # Match ID-### - pt1, ID-### - pt2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E? [-] pt|PT") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'pt', '')[1]
-                $filePartNumber = $filePartNum
-            }
-            # Match ID-### - part1, ID ### - part2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E? [-] part|PART") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'pt', '')[1]
-                $filePartNumber = $filePartNum
-            }
             # Match ID-###-pt1, ID-###-pt2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]pt|PT") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'pt', '')[1]
-                $filePartNumber = $filePartNum
-            }
+            # Match ID-### - pt1, ID-### - pt2, etc.
             # Match ID-###-part1, ID-###-part2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]part|PART") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'pt', '')[1]
-                $filePartNumber = $filePartNum
-            }
+            # Match ID-### - part1, ID ### - part2, etc.
             # Match ID-###-cd1, ID-###-cd2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?[-]cd|CD") {
-                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
-                $fileBaseNameUpperCleaned += $fileP1 + $fileP2
-                $filePartNum = ((($fileP3 -replace '-', '') -replace '0', '') -replace 'cd', '')[1]
-                $filePartNumber = $filePartNum
+            # Match ID-### - cd1, ID-### - cd2, etc.
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?\s?[-]\s?(cd|part|pt)?[-]?\d{1,3}") {
+                $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?\s?[-])"
+                $fileBaseNameUpperCleaned += $fileP1 + "-" + ($fileP2 -replace '-', '').Trim()
+                $filePartNum = ((($fileP3 -replace '-', '') -replace '^0{1,5}', '') -replace '(cd|part|pt)', '').Trim()
+                $filePartNumber = [int]$filePartNum
             }
 
             # Match everything else

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -92,7 +92,7 @@ function Convert-JVTitle {
                 }
                 if ($fileBaseNameUpper -eq 1) {
                     if ($partNum -ne '') {
-                        $fileBaseNameUpper = "$id-pt$PartNum"
+                        $fileBaseNameUpper = "$id-PT$PartNum"
                     } elseif ($id -ne '') {
                         $fileBaseNameUpper = "$id"
                     } else {
@@ -100,7 +100,7 @@ function Convert-JVTitle {
                     }
                 } else {
                     if ($partNum -ne '') {
-                        $fileBaseNameUpper[$index] = "$id-pt$PartNum"
+                        $fileBaseNameUpper[$index] = "$id-PT$PartNum"
                     } elseif ($id -ne '') {
                         $fileBaseNameUpper[$index] = "$id"
                     } else {
@@ -170,12 +170,12 @@ function Convert-JVTitle {
             # Match ID-###A, ID###B, etc.
             # Match ID-###-A, ID-###-B, etc.
             # Match ID-### - A, ID-### - B, etc.
-            if ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?\s?[-]?\s?[A-Z]$") {
+            if ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?R?\s?[-]?\s?[A-D]$") {
                 $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?)"
                 $fileBaseNameUpperCleaned += $fileP1 + "-" + (($fileP2 -replace '-', '') -replace '^0{1,5}', '').PadLeft(3, '0')
                 $fileP3 = ($fileP3 -replace '-', '').Trim()
                 $asciiP3 = [int][char]$fileP3
-                if ($asciiP3 -gt 64 -and $asciiP3 -lt 91) {
+                if ($asciiP3 -gt 64 -and $asciiP3 -lt 69) {
                     $filePartNumber = $asciiP3 - 64
                 }
             }
@@ -196,17 +196,17 @@ function Convert-JVTitle {
             # Match ID-### - part1, ID ### - part2, etc.
             # Match ID-###-cd1, ID-###-cd2, etc.
             # Match ID-### - cd1, ID-### - cd2, etc.
-            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?\s?[-]\s?(cd|part|pt)?[-]?\d{1,3}") {
+            elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?R?\s?[-]\s?(cd|part|pt)?[-]?\d{1,3}") {
                 $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?\s?[-])"
-                $fileBaseNameUpperCleaned += $fileP1 + "-" + (($fileP2 -replace '-', '') -replace '0{1,5}', '').Trim().PadLeft(3, '0')
-                $filePartNum = ((($fileP3 -replace '-', '') -replace '^0{1,5}', '') -replace '(cd|part|pt)', '').Trim()
+                $fileBaseNameUpperCleaned += $fileP1 + "-" + (($fileP2 -replace '-', '') -replace '^0{1,5}', '').Trim().PadLeft(3, '0')
+                $filePartNum = ((($fileP3.Trim() -replace '-', '') -replace '^0{1,5}', '') -replace '(cd|part|pt)', '')
                 $filePartNumber = [int]$filePartNum
             }
 
             # Match everything else
             else {
                 $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6})"
-                if ($fileP3 -match '^Z' -or $fileP3 -match '^E') {
+                if ($fileP3 -match '^[ZER]') {
                     $fileBaseNameUpperCleaned += $fileP1 + $fileP2 + $fileP3
                 } else {
                     $fileBaseNameUpperCleaned += $fileP1 + $fileP2

--- a/src/Tests/Unit/Javinizer-Function.Tests.ps1
+++ b/src/Tests/Unit/Javinizer-Function.Tests.ps1
@@ -122,6 +122,28 @@ InModuleScope 'Javinizer' {
                 $results.Id | Should -Be (,"IBW-230Z" * $fileNames.Length)
                 $results.PartNumber | Should -Be ((1..4) * [Math]::Ceiling($fileNames.Length / 4))[0..($fileNames.Length - 1)]
             }
+
+            It 'Should fail for multiparts > D except Z, E, R. Numerics are OK.' {
+                $fileNames = @(
+                    "bbi-094f.wmv",
+                    "bbi-094 - g.mp4",
+                    "bbi-094-pt5.mp4"
+                )
+
+                $files = @()
+                foreach($file in $FileNames) {
+                    $file = [PSCustomObject]@{
+                        Name = $file
+                        BaseName = $file.Substring(0, $file.Length - 4)
+                    }
+                    $files += $file
+                }
+
+                $results = Convert-JVTitle $files -RegexEnabled $false
+                $results.ContentId | Should -Be (,"BBI00094" * $fileNames.Length)
+                $results.Id | Should -Be (,"BBI-094" * $fileNames.Length)
+                $results.PartNumber | Should -Be ($null, $null, 5)
+            }
         }
 
     }#describe_PrivateFunctions

--- a/src/Tests/Unit/Javinizer-Function.Tests.ps1
+++ b/src/Tests/Unit/Javinizer-Function.Tests.ps1
@@ -38,7 +38,11 @@ InModuleScope 'Javinizer' {
                     "bbi-094 - cd14.wmv",
                     "bbi00094o.wmv",
                     "bbi00094-p.wmv",
-                    "bbi00094 - q.wmv"
+                    "bbi00094 - q.wmv",
+                    "bbi00094-pt18.wmv",
+                    "bbi00094 - pt19.wmv",
+                    "bbi00094-cd20.wmv",
+                    "bbi00094 - cd21.wmv"
                 )
 
                 Mock Get-ChildItem {
@@ -54,7 +58,7 @@ InModuleScope 'Javinizer' {
                 }
 
                 $files = Get-ChildItem
-                $results = Convert-JVTitle $files
+                $results = Convert-JVTitle $files -RegexEnabled $false
                 $results.ContentId | Should -Be (,"BBI00094" * $fileNames.Length)
                 $results.Id | Should -Be (,"BBI-094" * $fileNames.Length)
                 $results.PartNumber | Should -Be (1..$fileNames.Length)

--- a/src/Tests/Unit/Javinizer-Function.Tests.ps1
+++ b/src/Tests/Unit/Javinizer-Function.Tests.ps1
@@ -20,48 +20,107 @@ InModuleScope 'Javinizer' {
     #-------------------------------------------------------------------------
     Describe 'Javinizer Private Function Tests' -Tag Unit {
         Context 'Convert-JVTitle' {
+
             It 'Should convert multipart ID-### accordingly' {
                 $fileNames = @(
                     "bbi-094a.wmv",
                     "bbi-094-b.wmv",
                     "bbi-094 - c.wmv",
                     "bbi-094-4.wmv",
-                    "bbi-094 - 5.wmv",
-                    "bbi-094-06.wmv",
-                    "bbi-094-007.wmv",
-                    "bbi-094 - 008.wmv",
-                    "bbi-094-pt9.wmv",
-                    "bbi-094 - pt10.wmv",
-                    "bbi-094-part11.wmv",
-                    "bbi-094 - part12.wmv",
-                    "bbi-094-cd13.wmv",
-                    "bbi-094 - cd14.wmv",
-                    "bbi00094o.wmv",
-                    "bbi00094-p.wmv",
-                    "bbi00094 - q.wmv",
-                    "bbi00094-pt18.wmv",
-                    "bbi00094 - pt19.wmv",
-                    "bbi00094-cd20.wmv",
-                    "bbi00094 - cd21.wmv"
+                    "bbi-094 - 1.wmv",
+                    "bbi-094-02.wmv",
+                    "bbi-094-003.wmv",
+                    "bbi-094 - 004.wmv",
+                    "bbi-094-pt1.wmv",
+                    "bbi-094 - pt2.wmv",
+                    "bbi-094-part3.wmv",
+                    "bbi-094 - part4.wmv",
+                    "bbi-094-cd1.wmv",
+                    "bbi-094 - cd2.wmv",
+                    "bbi00094c.wmv",
+                    "bbi00094-d.wmv",
+                    "bbi00094 - a.wmv",
+                    "bbi00094-pt2.wmv",
+                    "bbi00094 - pt3.wmv",
+                    "bbi00094-cd4.wmv",
+                    "bbi00094 - cd1.wmv"
                 )
 
-                Mock Get-ChildItem {
-                    $files = @()
-                    foreach($file in $fileNames) {
-                        $file = [PSCustomObject]@{
-                            Name = $file
-                            BaseName = $file.Substring(0, $file.Length - 4)
-                        }
-                        $files += $file
+                $files = @()
+                foreach($file in $FileNames) {
+                    $file = [PSCustomObject]@{
+                        Name = $file
+                        BaseName = $file.Substring(0, $file.Length - 4)
                     }
-                    return $files
+                    $files += $file
                 }
 
-                $files = Get-ChildItem
                 $results = Convert-JVTitle $files -RegexEnabled $false
                 $results.ContentId | Should -Be (,"BBI00094" * $fileNames.Length)
                 $results.Id | Should -Be (,"BBI-094" * $fileNames.Length)
-                $results.PartNumber | Should -Be (1..$fileNames.Length)
+                $results.PartNumber | Should -Be ((1..4) * [Math]::Ceiling($fileNames.Length / 4))[0..($fileNames.Length - 1)]
+            }
+
+            It 'Should work fine for ID ending in E, Z and R' {
+                $fileNames = @(
+                    "ibw-230z.mp4",
+                    "ktra-213e.mp4",
+                    "gesd-093r.mp4"
+                )
+
+                $files = @()
+                foreach($file in $FileNames) {
+                    $file = [PSCustomObject]@{
+                        Name = $file
+                        BaseName = $file.Substring(0, $file.Length - 4)
+                    }
+                    $files += $file
+                }
+
+                $results = Convert-JVTitle $files -RegexEnabled $false
+                $results.ContentId | Should -Be ("IBW00230Z", "KTRA00213E", "GESD00093R")
+                $results.Id | Should -Be ("IBW-230Z", "KTRA-213E", "GESD-093R")
+                $results.PartNumber | Should -Be (,$null * $fileNames.Length)
+            }
+
+            It 'Should work fine for multipart ID ending in E, Z and R' {
+                $fileNames = @(
+                    "ibw-230za.mp4",
+                    "ibw-230z-b.mp4",
+                    "ibw-230z - c.mp4",
+                    "ibw-230z-4.mp4",
+                    "ibw-230z - 1.mp4",
+                    "ibw-230z-02.mp4",
+                    "ibw-230z-003.mp4",
+                    "ibw-230z - 004.mp4",
+                    "ibw-230z-pt1.mp4",
+                    "ibw-230z - pt2.mp4",
+                    "ibw-230z-part3.mp4",
+                    "ibw-230z - part4.mp4",
+                    "ibw-230z-cd1.mp4",
+                    "ibw-230z - cd2.mp4",
+                    "ibw00230zc.mp4",
+                    "ibw00230z-d.mp4",
+                    "ibw00230z - a.mp4",
+                    "ibw00230z-pt2.mp4",
+                    "ibw00230z - pt3.mp4",
+                    "ibw00230z-cd4.mp4",
+                    "ibw00230z - cd1.mp4"
+                )
+
+                $files = @()
+                foreach($file in $FileNames) {
+                    $file = [PSCustomObject]@{
+                        Name = $file
+                        BaseName = $file.Substring(0, $file.Length - 4)
+                    }
+                    $files += $file
+                }
+
+                $results = Convert-JVTitle $files -RegexEnabled $false
+                $results.ContentId | Should -Be (,"IBW00230Z" * $fileNames.Length)
+                $results.Id | Should -Be (,"IBW-230Z" * $fileNames.Length)
+                $results.PartNumber | Should -Be ((1..4) * [Math]::Ceiling($fileNames.Length / 4))[0..($fileNames.Length - 1)]
             }
         }
 

--- a/src/Tests/Unit/Javinizer-Function.Tests.ps1
+++ b/src/Tests/Unit/Javinizer-Function.Tests.ps1
@@ -19,13 +19,48 @@ InModuleScope 'Javinizer' {
     $WarningPreference = "SilentlyContinue"
     #-------------------------------------------------------------------------
     Describe 'Javinizer Private Function Tests' -Tag Unit {
-        Context 'FunctionName' {
-            <#
-            It 'should ...' {
+        Context 'Convert-JVTitle' {
+            It 'Should convert multipart ID-### accordingly' {
+                $fileNames = @(
+                    "bbi-094a.wmv",
+                    "bbi-094-b.wmv",
+                    "bbi-094 - c.wmv",
+                    "bbi-094-4.wmv",
+                    "bbi-094 - 5.wmv",
+                    "bbi-094-06.wmv",
+                    "bbi-094-007.wmv",
+                    "bbi-094 - 008.wmv",
+                    "bbi-094-pt9.wmv",
+                    "bbi-094 - pt10.wmv",
+                    "bbi-094-part11.wmv",
+                    "bbi-094 - part12.wmv",
+                    "bbi-094-cd13.wmv",
+                    "bbi-094 - cd14.wmv",
+                    "bbi00094o.wmv",
+                    "bbi00094-p.wmv",
+                    "bbi00094 - q.wmv"
+                )
 
-            }#it
-            #>
-        }#context_FunctionName
+                Mock Get-ChildItem {
+                    $files = @()
+                    foreach($file in $fileNames) {
+                        $file = [PSCustomObject]@{
+                            Name = $file
+                            BaseName = $file.Substring(0, $file.Length - 4)
+                        }
+                        $files += $file
+                    }
+                    return $files
+                }
+
+                $files = Get-ChildItem
+                $results = Convert-JVTitle $files
+                $results.ContentId | Should -Be (,"BBI00094" * $fileNames.Length)
+                $results.Id | Should -Be (,"BBI-094" * $fileNames.Length)
+                $results.PartNumber | Should -Be (1..$fileNames.Length)
+            }
+        }
+
     }#describe_PrivateFunctions
     Describe 'Javinizer Public Function Tests' -Tag Unit {
         Context 'FunctionName' {

--- a/src/Tests/Unit/Javinizer-Function.Tests.ps1
+++ b/src/Tests/Unit/Javinizer-Function.Tests.ps1
@@ -19,8 +19,22 @@ InModuleScope 'Javinizer' {
     $WarningPreference = "SilentlyContinue"
     #-------------------------------------------------------------------------
     Describe 'Javinizer Private Function Tests' -Tag Unit {
-        Context 'Convert-JVTitle' {
 
+        BeforeAll {
+            function Get-Files ($fileNames) {
+                $files = @()
+                foreach($file in $FileNames) {
+                    $file = [PSCustomObject]@{
+                        Name = $file
+                        BaseName = $file.Substring(0, $file.Length - 4)
+                    }
+                    $files += $file
+                }
+                return $files
+            }
+        }
+
+        Context 'Convert-JVTitle' {
             It 'Should convert multipart ID-### accordingly' {
                 $fileNames = @(
                     "bbi-094a.wmv",
@@ -46,15 +60,7 @@ InModuleScope 'Javinizer' {
                     "bbi00094 - cd1.wmv"
                 )
 
-                $files = @()
-                foreach($file in $FileNames) {
-                    $file = [PSCustomObject]@{
-                        Name = $file
-                        BaseName = $file.Substring(0, $file.Length - 4)
-                    }
-                    $files += $file
-                }
-
+                $files = Get-Files $fileNames
                 $results = Convert-JVTitle $files -RegexEnabled $false
                 $results.ContentId | Should -Be (,"BBI00094" * $fileNames.Length)
                 $results.Id | Should -Be (,"BBI-094" * $fileNames.Length)
@@ -108,15 +114,7 @@ InModuleScope 'Javinizer' {
                     "ibw00230z - cd1.mp4"
                 )
 
-                $files = @()
-                foreach($file in $FileNames) {
-                    $file = [PSCustomObject]@{
-                        Name = $file
-                        BaseName = $file.Substring(0, $file.Length - 4)
-                    }
-                    $files += $file
-                }
-
+                $files = Get-Files $fileNames
                 $results = Convert-JVTitle $files -RegexEnabled $false
                 $results.ContentId | Should -Be (,"IBW00230Z" * $fileNames.Length)
                 $results.Id | Should -Be (,"IBW-230Z" * $fileNames.Length)
@@ -130,15 +128,7 @@ InModuleScope 'Javinizer' {
                     "bbi-094-pt5.mp4"
                 )
 
-                $files = @()
-                foreach($file in $FileNames) {
-                    $file = [PSCustomObject]@{
-                        Name = $file
-                        BaseName = $file.Substring(0, $file.Length - 4)
-                    }
-                    $files += $file
-                }
-
+                $files = Get-Files $fileNames
                 $results = Convert-JVTitle $files -RegexEnabled $false
                 $results.ContentId | Should -Be (,"BBI00094" * $fileNames.Length)
                 $results.Id | Should -Be (,"BBI-094" * $fileNames.Length)


### PR DESCRIPTION
The latest version (`v2.0.2`) of Javinizer's `-Update` allows re-downloading of trailers and re-creation of NFO files, but there's a bug if `match.regex` is not used.

For instance, if I have the following set of files:

```
├── bbi-094a.wmv
└── bbi-094b.wmv
```

The initial multi-part files are `bbi-094a.wmv` and `bbi-094b.wmv` respectively.

Using only `dmmja` as the sole aggregator and running `Javinizer` for renaming and moving files, I would then obtain

```
├── bbi00094-pt1.wmv
├── bbi00094-pt1.nfo
├── bbi00094-pt2.wmv
└── bbi00094-pt2.nfo
```

If we now run `Javinizer -Update` to force an update, you will see that `Javinizer` is unable to match any search results.

```
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-1] [Get-DmmUrl] Performing [GET] on URL [https://www.dmm.co.jp/search/?redirect=1&enc=UTF-8&category=&searchstr=BBI0009400000T]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-2] [Get-DmmUrl] Performing [GET] on URL [https://www.dmm.co.jp/search/?redirect=1&enc=UTF-8&category=&searchstr=BBI0009400000T]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-1] [Get-DmmUrl] Searching [3] of [5] results for [BBI00094-PT-1]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-2] [Get-DmmUrl] Searching [3] of [5] results for [BBI00094-PT-2]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-1] [Get-DmmUrl] Performing [GET] on URL [https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=pred00251/]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-2] [Get-DmmUrl] Performing [GET] on URL [https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=pred00251/]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-1] [Get-DmmUrl] Result [1] is [pred00251]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-1] [Get-DmmUrl] Performing [GET] on URL [https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=h_1340buzx00001/]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-2] [Get-DmmUrl] Result [1] is [pred00251]
[2020-09-22T16:59:19][DEBUG] [BBI00094-PT-2] [Get-DmmUrl] Performing [GET] on URL [https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=h_1340buzx00001/]
[2020-09-22T16:59:20][DEBUG] [BBI00094-PT-1] [Get-DmmUrl] Result [2] is [h_1340buzx00001]
[2020-09-22T16:59:20][DEBUG] [BBI00094-PT-1] [Get-DmmUrl] Performing [GET] on URL [https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=ssni00877/]
[2020-09-22T16:59:20][DEBUG] [BBI00094-PT-2] [Get-DmmUrl] Result [2] is [h_1340buzx00001]
[2020-09-22T16:59:20][DEBUG] [BBI00094-PT-2] [Get-DmmUrl] Performing [GET] on URL [https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=ssni00877/]
[2020-09-22T16:59:20][DEBUG] [BBI00094-PT-1] [Get-DmmUrl] Result [3] is [ssni00877]
[2020-09-22T16:59:20][WARN ] [BBI00094-PT-1] [Get-DmmUrl] not matched on DMM
[2020-09-22T16:59:20][DEBUG] [BBI00094-PT-1] [Get-JVData] [Search - Dmm] [Url - ]
[2020-09-22T16:59:20][DEBUG] [BBI00094-PT-1] [Get-JVData] [Success - Scraper jobs] []
[2020-09-22T16:59:20][DEBUG] [BBI00094-PT-1] [Get-JVData] [Removed - Scraper jobs]
[2020-09-22T16:59:20][WARN ] [bbi00094-pt1.wmv] Skipped -- not matched
[2020-09-22T16:59:21][DEBUG] [BBI00094-PT-2] [Get-DmmUrl] Result [3] is [ssni00877]
[2020-09-22T16:59:21][WARN ] [BBI00094-PT-2] [Get-DmmUrl] not matched on DMM
[2020-09-22T16:59:21][DEBUG] [BBI00094-PT-2] [Get-JVData] [Search - Dmm] [Url - ]
[2020-09-22T16:59:21][DEBUG] [BBI00094-PT-2] [Get-JVData] [Success - Scraper jobs] []
[2020-09-22T16:59:21][DEBUG] [BBI00094-PT-2] [Get-JVData] [Removed - Scraper jobs]
[2020-09-22T16:59:21][WARN ] [bbi00094-pt2.wmv] Skipped -- not matched
```

As it appears, the filenames were not converted by `Convert-JVTitle` properly. This PR hopes to solve that problem.

In addition to the updates, I've included the following changes:
- Streamlined the conversion process of Alphabetical parts to part numbers without using too many `if..elseif..else` statements
- Streamlined ID matching to a single regex.
- Included Unit Test for validating different use cases.

Note: There are a couple of edge-cases that I've not tested. It may be necessary to include them for unit testing.