### PR TITLE
[Fix] When -Url is specified, Get-JVData does not work for DmmJa

### DIFF
--- a/src/Javinizer/Private/Scraper.Dmm.ps1
+++ b/src/Javinizer/Private/Scraper.Dmm.ps1
@@ -371,7 +371,7 @@ function Get-DmmCoverUrl {
 
     process {
         try {
-            $coverUrl = ($Webrequest.Content | Select-String -Pattern '(https:\/\/pics\.dmm\.co\.jp\/(mono\/movie\/adult|digital\/video)\/(.*)/(.*)\.jpg)').Matches.Groups[1].Value -replace 'ps.jpg', 'pl.jpg'
+            $coverUrl = ($Webrequest.Content | Select-String -Pattern '(https:\/\/pics\.dmm\.co\.jp\/(mono\/movie\/adult|digital\/(?:video|amateur))\/(.*)\/(.*)\.jpg)').Matches.Groups[1].Value -replace 'ps.jpg', 'pl.jpg'
         } catch {
             return
         }

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -59,6 +59,7 @@ function Get-JVData {
         [Boolean]$DmmScrapeActress,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Id')]
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Url')]
         [Alias('location.uncensorcsv')]
         [System.IO.FileInfo]$UncensorCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvUncensor.csv'),
 
@@ -67,7 +68,7 @@ function Get-JVData {
         [PSObject]$Settings,
 
         [Parameter(ParameterSetName = 'Url')]
-        [PSObject]$Url
+        [Array]$Url
     )
 
     process {
@@ -221,11 +222,11 @@ function Get-JVData {
                 }
 
                 if ($DmmJa) {
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] [Search - Dmm] [Url - $DmmUrl]"
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] [Search - DmmJa] [Url - $DmmJaUrl]"
                     Start-ThreadJob -Name "jvdata-Dmm" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
-                        if ($using:DmmUrl) {
-                            $using:DmmUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
+                        if ($using:DmmJaUrl) {
+                            $using:DmmJaUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
                         } elseif ($using:jvDmmUrl) {
                             $jvDmmUrl = $using:jvDmmUrl
                             $jvDmmUrl.Ja | Get-DmmData -ScrapeActress:$using:DmmScrapeActress


### PR DESCRIPTION
When `-Url` is specified under the `Path` parameter set, DmmJa does not work due to a variable name typo.

Additionally, `Get-JVData` is unusable when specified with `-Url` and `-UncensorCsvPath` is specified, throwing the following error:

```powershell
Line |
 670 |  …  $javData = Get-JVData -Url $Url -Settings $Settings -UncensorCsvPath …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Parameter set cannot be resolved using the specified named parameters. One or more parameters issued cannot be used together or an insufficient number of
     | parameters were provided.
```

This PR fixes both problems.

**Edit:** I found a small bug when grabbing from DmmJa's Amateur site. Fix applied.