### PR TITLE
[Proposal][Feature] Convert DMM's ContentID to standard ID

### DIFF
--- a/src/Javinizer/Private/Convert-JVString.ps1
+++ b/src/Javinizer/Private/Convert-JVString.ps1
@@ -90,6 +90,7 @@ function Convert-JVString {
         $actresses = ($actressObject | Sort-Object) -join $Delimiter
         $convertedName = $FormatString `
             -replace '<ID>', "$($Data.Id)" `
+            -replace '<CONTENTID>', "$($Data.ContentId)" `
             -replace '<TITLE>', "$($Data.Title)" `
             -replace '<RELEASEDATE>', "$($Data.ReleaseDate)" `
             -replace '<YEAR>', "$(($Data.ReleaseDate -split '-')[0])" `

--- a/src/Javinizer/Private/Scraper.Dmm.ps1
+++ b/src/Javinizer/Private/Scraper.Dmm.ps1
@@ -147,7 +147,7 @@ function Get-DmmMaker {
 
     process {
         try {
-            $maker = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|\/en\/mono\/dvd\/)-\/list\/=\/article=maker\/id=\d*\/">(.*)<\/a>').Matches.Groups[2].Value
+            $maker = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=maker\/id=\d*\/">(.*)<\/a>').Matches.Groups[2].Value
         } catch {
             return
         }
@@ -163,7 +163,7 @@ function Get-DmmLabel {
 
     process {
         try {
-            $label = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|\/en\/mono\/dvd\/)-\/list\/=\/article=label\/id=\d*\/">(.*)<\/a>').Matches.Groups[2].Value
+            $label = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=label\/id=\d*\/">(.*)<\/a>').Matches.Groups[2].Value
         } catch {
             return
         }
@@ -179,7 +179,7 @@ function Get-DmmSeries {
 
     process {
         try {
-            $series = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|\/en\/mono\/dvd\/)-\/list\/=\/article=series\/id=\d*\/">(.*)<\/a><\/td>').Matches.Groups[2].Value
+            $series = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=series\/id=\d*\/">(.*)<\/a><\/td>').Matches.Groups[2].Value
         } catch {
             return
         }

--- a/src/Javinizer/Private/Scraper.Dmm.ps1
+++ b/src/Javinizer/Private/Scraper.Dmm.ps1
@@ -25,9 +25,10 @@ function Get-DmmId {
             # Expects ###ID##### or ID#####
             $contentId = Get-DmmContentId $Webrequest
             $Id = $contentId
-            $m = ($contentId | Select-String -Pattern '\d*([a-z]+)(\d+)$' -AllMatches).Matches
+            $m = ($contentId | Select-String -Pattern '\d*([a-z]+)(\d+)(.*)$' -AllMatches).Matches
+
             if($m.Groups.Count -gt 2 -and $m.Groups[1] -and $m.Groups[2]) {
-                $Id = $m.Groups[1].Value.ToUpper() + "-" + ($m.Groups[2].Value -replace '^0{1,5}', '').PadLeft(3, '0')
+                $Id = $m.Groups[1].Value.ToUpper() + "-" + ($m.Groups[2].Value -replace '^0{1,5}', '').PadLeft(3, '0') + $m.Groups[3].Value.ToUpper()
             }
         } catch {
             return

--- a/src/Javinizer/Private/Scraper.Dmm.ps1
+++ b/src/Javinizer/Private/Scraper.Dmm.ps1
@@ -14,6 +14,28 @@ function Get-DmmContentId {
     }
 }
 
+function Get-DmmId {
+    param (
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Object]$Webrequest
+    )
+
+    process {
+        try {
+            # Expects ###ID##### or ID#####
+            $contentId = Get-DmmContentId $Webrequest
+            $Id = $contentId
+            $m = ($contentId | Select-String -Pattern '\d*([a-z]+)(\d+)$' -AllMatches).Matches
+            if($m.Groups.Count -gt 2 -and $m.Groups[1] -and $m.Groups[2]) {
+                $Id = $m.Groups[1].Value.ToUpper() + "-" + ($m.Groups[2].Value -replace '^0{1,5}', '').PadLeft(3, '0')
+            }
+        } catch {
+            return
+        }
+        Write-Output $Id
+    }
+}
+
 function Get-DmmTitle {
     param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]

--- a/src/Javinizer/Private/Scraper.Dmm.ps1
+++ b/src/Javinizer/Private/Scraper.Dmm.ps1
@@ -24,7 +24,6 @@ function Get-DmmId {
         try {
             # Expects ###ID##### or ID#####
             $contentId = Get-DmmContentId $Webrequest
-            $Id = $contentId
             $m = ($contentId | Select-String -Pattern '\d*([a-z]+)(\d+)(.*)$' -AllMatches).Matches
 
             if($m.Groups.Count -gt 2 -and $m.Groups[1] -and $m.Groups[2]) {

--- a/src/Javinizer/Public/Get-DmmData.ps1
+++ b/src/Javinizer/Public/Get-DmmData.ps1
@@ -7,10 +7,7 @@ function Get-DmmData {
         [String]$Url,
 
         [Parameter()]
-        [Boolean]$ScrapeActress,
-
-        [Parameter()]
-        [String]$IdPreference = "id"
+        [Boolean]$ScrapeActress
     )
 
     process {
@@ -48,7 +45,7 @@ function Get-DmmData {
         $movieDataObject = [PSCustomObject]@{
             Source        = if ($Url -match '/en/') { 'dmm' } else { 'dmmja' }
             Url           = $Url
-            Id            = if ($IdPreference -eq "id") { Get-DmmId -WebRequest $webRequest } elseif ($IdPreference -eq "contentid") { Get-DmmContentId -WebRequest $webRequest }
+            Id            = Get-DmmId -WebRequest $webRequest
             ContentId     = Get-DmmContentId -WebRequest $webRequest
             Title         = Get-DmmTitle -WebRequest $webRequest
             Description   = Get-DmmDescription -WebRequest $webRequest

--- a/src/Javinizer/Public/Get-DmmData.ps1
+++ b/src/Javinizer/Public/Get-DmmData.ps1
@@ -44,7 +44,8 @@ function Get-DmmData {
         $movieDataObject = [PSCustomObject]@{
             Source        = if ($Url -match '/en/') { 'dmm' } else { 'dmmja' }
             Url           = $Url
-            Id            = Get-DmmContentId -WebRequest $webRequest
+            Id            = Get-DmmId -WebRequest $webRequest
+            ContentId     = Get-DmmContentId -WebRequest $webRequest
             Title         = Get-DmmTitle -WebRequest $webRequest
             Description   = Get-DmmDescription -WebRequest $webRequest
             ReleaseDate   = Get-DmmReleaseDate -WebRequest $webRequest

--- a/src/Javinizer/Public/Get-DmmData.ps1
+++ b/src/Javinizer/Public/Get-DmmData.ps1
@@ -12,8 +12,14 @@ function Get-DmmData {
 
     process {
         $movieDataObject = @()
+        $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $cookie = New-Object System.Net.Cookie
+        $cookie.Name = 'age_check_done'
+        $cookie.Value = '1'
+        $cookie.Domain = 'dmm.co.jp'
+        $session.Cookies.Add($cookie)
+
         if ($Url -match '/en/') {
-            $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
             $cookie = New-Object System.Net.Cookie
             $cookie.Name = 'ckcy'
             $cookie.Value = '2'
@@ -22,11 +28,6 @@ function Get-DmmData {
             $cookie = New-Object System.Net.Cookie
             $cookie.Name = 'cklg'
             $cookie.Value = 'en'
-            $cookie.Domain = 'dmm.co.jp'
-            $session.Cookies.Add($cookie)
-            $cookie = New-Object System.Net.Cookie
-            $cookie.Name = 'age_check_done'
-            $cookie.Value = '1'
             $cookie.Domain = 'dmm.co.jp'
             $session.Cookies.Add($cookie)
         }

--- a/src/Javinizer/Public/Get-DmmData.ps1
+++ b/src/Javinizer/Public/Get-DmmData.ps1
@@ -7,7 +7,10 @@ function Get-DmmData {
         [String]$Url,
 
         [Parameter()]
-        [Boolean]$ScrapeActress
+        [Boolean]$ScrapeActress,
+
+        [Parameter()]
+        [String]$IdPreference = "id"
     )
 
     process {
@@ -45,7 +48,7 @@ function Get-DmmData {
         $movieDataObject = [PSCustomObject]@{
             Source        = if ($Url -match '/en/') { 'dmm' } else { 'dmmja' }
             Url           = $Url
-            Id            = Get-DmmId -WebRequest $webRequest
+            Id            = if ($IdPreference -eq "id") { Get-DmmId -WebRequest $webRequest } elseif ($IdPreference -eq "contentid") { Get-DmmContentId -WebRequest $webRequest }
             ContentId     = Get-DmmContentId -WebRequest $webRequest
             Title         = Get-DmmTitle -WebRequest $webRequest
             Description   = Get-DmmDescription -WebRequest $webRequest

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -38,6 +38,10 @@ function Get-JVAggregatedData {
         [Array]$IdPriority,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
+        [Alias('sort.metadata.priority.contentid')]
+        [Array]$ContentIdPriority,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
         [Alias('sort.metadata.priority.label')]
         [Array]$LabelPriority,
 
@@ -151,6 +155,7 @@ function Get-JVAggregatedData {
             $DirectorPriority = $Settings.'sort.metadata.priority.director'
             $GenrePriority = $Settings.'sort.metadata.priority.genre'
             $IdPriority = $Settings.'sort.metadata.priority.id'
+            $ContentIdPriority = $Settings.'sort.metadata.priority.contentid'
             $LabelPriority = $Settings.'sort.metadata.priority.label'
             $MakerPriority = $Settings.'sort.metadata.priority.maker'
             $RatingPriority = $Settings.'sort.metadata.priority.rating'
@@ -184,6 +189,7 @@ function Get-JVAggregatedData {
 
         $aggregatedDataObject = [PSCustomObject]@{
             Id             = $null
+            ContentId      = $null
             DisplayName    = $null
             Title          = $null
             AlternateTitle = $null
@@ -220,7 +226,8 @@ function Get-JVAggregatedData {
             'Series',
             'ScreenshotUrl',
             'Title',
-            'TrailerUrl'
+            'TrailerUrl',
+            'ContentId'
         )
 
         foreach ($field in $metadataFields) {

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -143,7 +143,11 @@ function Get-JVAggregatedData {
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
         [Alias('sort.metadata.nfo.format.tagline')]
-        [String]$Tagline
+        [String]$Tagline,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
+        [Alias('scraper.option.idpreference')]
+        [String]$IdPreference
     )
 
     process {
@@ -179,6 +183,7 @@ function Get-JVAggregatedData {
             $UnknownActress = $Settings.'sort.metadata.nfo.unknownactress'
             $Tag = $Settings.'sort.metadata.nfo.format.tag'
             $Tagline = $Settings.'sort.metadata.nfo.format.tagline'
+            $IdPreference = $Settings.'scraper.option.idpreference'
             if ($Settings.'location.genrecsv' -ne '') {
                 $GenreCsvPath = $Settings.'location.genrecsv'
             }
@@ -238,6 +243,12 @@ function Get-JVAggregatedData {
                 if ($null -eq $aggregatedDataObject.$field) {
                     if ($field -eq 'AlternateTitle') {
                         $aggregatedDataObject.$field = $sourceData.Title
+                    } elseif ($field -eq 'Id') {
+                        if ($IdPreference -eq 'contentid') {
+                            $aggregatedDataObject.$field = $sourceData.ContentId
+                        } else {
+                            $aggregatedDataObject.$field = $sourceData.Id
+                        }
                     } else {
                         $aggregatedDataObject.$field = $sourceData.$field
                     }

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -55,16 +55,8 @@ function Get-JVData {
         [String]$JavlibraryBaseUrl = 'https://www.javlibrary.com',
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Id')]
-        [Alias('scraper.movie.dmm.scrapeactress')]
+        [Alias('scraper.option.dmm.scrapeactress')]
         [Boolean]$DmmScrapeActress,
-
-        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Id')]
-        [Alias('scraper.movie.dmm.idpreference')]
-        [String]$DmmIdPreference,
-
-        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Id')]
-        [Alias('scraper.movie.dmm.r18preference')]
-        [String]$R18IdPreference,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Id')]
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Url')]
@@ -104,8 +96,6 @@ function Get-JVData {
             $JavbusJa = $Settings.'scraper.movie.javbusja'
             $JavbusZh = $Settings.'scraper.movie.javbuszh'
             $DmmScrapeActress = $Settings.'scraper.option.dmm.scrapeactress'
-            $DmmIdPreference = $Settings.'scraper.option.dmm.idpreference'
-            $R18IdPreference = $Settings.'scraper.option.r18.idpreference'
             if ($Settings.'location.uncensorcsv' -ne '') {
                 $UncensorCsvPath = $Settings.'location.uncensorcsv'
             }
@@ -138,11 +128,11 @@ function Get-JVData {
                     Start-ThreadJob -Name "jvdata-R18" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
                         if ($using:R18Url) {
-                            $using:R18Url | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath -IdPreference:$using:R18IdPreference
+                            $using:R18Url | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath
                         } elseif ($using:jvR18Url) {
                             $jvR18Url = $using:jvR18Url
                             if ($jvR18Url) {
-                                $jvR18Url.En | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath -IdPreference:$using:R18IdPreference
+                                $jvR18Url.En | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath
                             }
                         }
                     } | Out-Null
@@ -153,11 +143,11 @@ function Get-JVData {
                     Start-ThreadJob -Name "jvdata-R18Zh" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
                         if ($using:R18ZhUrl) {
-                            $using:R18ZhUrl | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath -IdPreference:$using:R18IdPreference
+                            $using:R18ZhUrl | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath
                         } elseif ($using:jvR18Url) {
                             $jvR18Url = $using:jvR18Url
                             if ($jvR18Url) {
-                                $jvR18Url.Zh | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath -IdPreference:$using:R18IdPreference
+                                $jvR18Url.Zh | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath
                             }
                         }
                     } | Out-Null
@@ -223,23 +213,23 @@ function Get-JVData {
                     Start-ThreadJob -Name "jvdata-Dmm" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
                         if ($using:DmmUrl) {
-                            $using:DmmUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress -IdPreference:$using:DmmIdPreference
+                            $using:DmmUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
                         } elseif ($using:jvDmmUrl) {
                             $jvDmmUrl = $using:jvDmmUrl
-                            $jvDmmUrl.En | Get-DmmData -ScrapeActress:$using:DmmScrapeActress -IdPreference:$using:DmmIdPreference
+                            $jvDmmUrl.En | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
                         }
                     } | Out-Null
                 }
 
                 if ($DmmJa) {
                     Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] [Search - DmmJa] [Url - $DmmJaUrl]"
-                    Start-ThreadJob -Name "jvdata-Dmm" -ThrottleLimit $throttleLimit -ScriptBlock {
+                    Start-ThreadJob -Name "jvdata-DmmJa" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
                         if ($using:DmmJaUrl) {
-                            $using:DmmJaUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress -IdPreference:$using:DmmIdPreference
+                            $using:DmmJaUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
                         } elseif ($using:jvDmmUrl) {
                             $jvDmmUrl = $using:jvDmmUrl
-                            $jvDmmUrl.Ja | Get-DmmData -ScrapeActress:$using:DmmScrapeActress -IdPreference:$using:DmmIdPreference
+                            $jvDmmUrl.Ja | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
                         }
                     } | Out-Null
                 }

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -59,6 +59,14 @@ function Get-JVData {
         [Boolean]$DmmScrapeActress,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Id')]
+        [Alias('scraper.movie.dmm.idpreference')]
+        [String]$DmmIdPreference,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Id')]
+        [Alias('scraper.movie.dmm.r18preference')]
+        [String]$R18IdPreference,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Id')]
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Url')]
         [Alias('location.uncensorcsv')]
         [System.IO.FileInfo]$UncensorCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvUncensor.csv'),
@@ -68,7 +76,7 @@ function Get-JVData {
         [PSObject]$Settings,
 
         [Parameter(ParameterSetName = 'Url')]
-        [Array]$Url
+        [PSObject]$Url
     )
 
     process {
@@ -96,6 +104,8 @@ function Get-JVData {
             $JavbusJa = $Settings.'scraper.movie.javbusja'
             $JavbusZh = $Settings.'scraper.movie.javbuszh'
             $DmmScrapeActress = $Settings.'scraper.option.dmm.scrapeactress'
+            $DmmIdPreference = $Settings.'scraper.option.dmm.idpreference'
+            $R18IdPreference = $Settings.'scraper.option.r18.idpreference'
             if ($Settings.'location.uncensorcsv' -ne '') {
                 $UncensorCsvPath = $Settings.'location.uncensorcsv'
             }
@@ -128,11 +138,11 @@ function Get-JVData {
                     Start-ThreadJob -Name "jvdata-R18" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
                         if ($using:R18Url) {
-                            $using:R18Url | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath
+                            $using:R18Url | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath -IdPreference:$using:R18IdPreference
                         } elseif ($using:jvR18Url) {
                             $jvR18Url = $using:jvR18Url
                             if ($jvR18Url) {
-                                $jvR18Url.En | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath
+                                $jvR18Url.En | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath -IdPreference:$using:R18IdPreference
                             }
                         }
                     } | Out-Null
@@ -143,11 +153,11 @@ function Get-JVData {
                     Start-ThreadJob -Name "jvdata-R18Zh" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
                         if ($using:R18ZhUrl) {
-                            $using:R18ZhUrl | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath
+                            $using:R18ZhUrl | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath -IdPreference:$using:R18IdPreference
                         } elseif ($using:jvR18Url) {
                             $jvR18Url = $using:jvR18Url
                             if ($jvR18Url) {
-                                $jvR18Url.Zh | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath
+                                $jvR18Url.Zh | Get-R18Data -UncensorCsvPath:$using:UncensorCsvPath -IdPreference:$using:R18IdPreference
                             }
                         }
                     } | Out-Null
@@ -213,10 +223,10 @@ function Get-JVData {
                     Start-ThreadJob -Name "jvdata-Dmm" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
                         if ($using:DmmUrl) {
-                            $using:DmmUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
+                            $using:DmmUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress -IdPreference:$using:DmmIdPreference
                         } elseif ($using:jvDmmUrl) {
                             $jvDmmUrl = $using:jvDmmUrl
-                            $jvDmmUrl.En | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
+                            $jvDmmUrl.En | Get-DmmData -ScrapeActress:$using:DmmScrapeActress -IdPreference:$using:DmmIdPreference
                         }
                     } | Out-Null
                 }
@@ -226,10 +236,10 @@ function Get-JVData {
                     Start-ThreadJob -Name "jvdata-Dmm" -ThrottleLimit $throttleLimit -ScriptBlock {
                         Import-Module $using:jvModulePath
                         if ($using:DmmJaUrl) {
-                            $using:DmmJaUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
+                            $using:DmmJaUrl | Get-DmmData -ScrapeActress:$using:DmmScrapeActress -IdPreference:$using:DmmIdPreference
                         } elseif ($using:jvDmmUrl) {
                             $jvDmmUrl = $using:jvDmmUrl
-                            $jvDmmUrl.Ja | Get-DmmData -ScrapeActress:$using:DmmScrapeActress
+                            $jvDmmUrl.Ja | Get-DmmData -ScrapeActress:$using:DmmScrapeActress -IdPreference:$using:DmmIdPreference
                         }
                     } | Out-Null
                 }

--- a/src/Javinizer/Public/Get-R18Data.ps1
+++ b/src/Javinizer/Public/Get-R18Data.ps1
@@ -7,7 +7,10 @@ function Get-R18Data {
         [String]$Url,
 
         [Parameter()]
-        [System.IO.FileInfo]$UncensorCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvUncensor.csv')
+        [System.IO.FileInfo]$UncensorCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvUncensor.csv'),
+
+        [Parameter()]
+        [String]$IdPreference = "id"
     )
 
     process {
@@ -29,7 +32,7 @@ function Get-R18Data {
             Source        = if ($Url -match 'lg=zh') { 'r18zh' } else { 'r18' }
             Url           = $Url
             ContentId     = Get-R18ContentId -WebRequest $webRequest
-            Id            = Get-R18Id -WebRequest $webRequest
+            Id            = if ($IdPreference -eq "id") { Get-R18Id -WebRequest $webRequest } elseif ($IdPreference -eq "contentid") { Get-R18ContentId -WebRequest $webRequest }
             Title         = Get-R18Title -WebRequest $webRequest -Replace $replaceHashTable
             Description   = Get-R18Description -WebRequest $webRequest
             ReleaseDate   = Get-R18ReleaseDate -WebRequest $webRequest

--- a/src/Javinizer/Public/Get-R18Data.ps1
+++ b/src/Javinizer/Public/Get-R18Data.ps1
@@ -7,10 +7,7 @@ function Get-R18Data {
         [String]$Url,
 
         [Parameter()]
-        [System.IO.FileInfo]$UncensorCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvUncensor.csv'),
-
-        [Parameter()]
-        [String]$IdPreference = "id"
+        [System.IO.FileInfo]$UncensorCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvUncensor.csv')
     )
 
     process {
@@ -32,7 +29,7 @@ function Get-R18Data {
             Source        = if ($Url -match 'lg=zh') { 'r18zh' } else { 'r18' }
             Url           = $Url
             ContentId     = Get-R18ContentId -WebRequest $webRequest
-            Id            = if ($IdPreference -eq "id") { Get-R18Id -WebRequest $webRequest } elseif ($IdPreference -eq "contentid") { Get-R18ContentId -WebRequest $webRequest }
+            Id            = Get-R18Id -WebRequest $webRequest
             Title         = Get-R18Title -WebRequest $webRequest -Replace $replaceHashTable
             Description   = Get-R18Description -WebRequest $webRequest
             ReleaseDate   = Get-R18ReleaseDate -WebRequest $webRequest

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -18,6 +18,8 @@
     "scraper.movie.r18": 1,
     "scraper.movie.r18zh": 0,
     "scraper.option.dmm.scrapeactress": 0,
+    "scraper.option.dmm.idpreference": "id",
+    "scraper.option.r18.idpreference": "id",
     "match.minimumfilesize": 0,
     "match.includedfileextension": [
         ".asf",
@@ -76,6 +78,7 @@
     "sort.metadata.priority.director": ["r18", "javlibrary"],
     "sort.metadata.priority.genre": ["r18", "javlibrary"],
     "sort.metadata.priority.id": ["r18", "javlibrary"],
+    "sort.metadata.priority.contentid": ["r18", "dmmja"],
     "sort.metadata.priority.label": ["r18", "javlibrary"],
     "sort.metadata.priority.maker": ["r18", "javlibrary"],
     "sort.metadata.priority.releasedate": ["r18", "javlibrary", "dmmja"],

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -18,8 +18,7 @@
     "scraper.movie.r18": 1,
     "scraper.movie.r18zh": 0,
     "scraper.option.dmm.scrapeactress": 0,
-    "scraper.option.dmm.idpreference": "id",
-    "scraper.option.r18.idpreference": "id",
+    "scraper.option.idpreference": "id",
     "match.minimumfilesize": 0,
     "match.includedfileextension": [
         ".asf",


### PR DESCRIPTION
The current `ID` is rather inconsistent with all other web providers. For instance, DMM uses a format of `ID#####` where # represents some kind of numeric value while others like Javlibrary uses the standard `ID-###`. Additionally, there's also no way to customize which type of ID I would like to use.

This exhibits a problem because I would prefer to have it use `ID-###` rather than `ID####`, but there is no way to reflect this choice in the settings file.

In this PR, I would like to propose to standardize the `ID` format to `ID-###` and keep `ID#####` as a separate ID, called `ContentID`. This would also allow customization in `sort.format.file` and others to support both `<ID>` and `<CONTID>`.

There are two ways to go about this problem.

1. Include a new field in `$Data` to support `ContentId` and `Id`. Possibly, include another field that keeps the original scraped id, called `ScrapeId`
2. Keep the original data structure, but make modifications to `Convert-JVString` to support `<CONTID>`.

Each of the above choices has its own repercussions:

1. Requires refactoring all aggregators to include the additional field for support
2. It's more tricky to maintain the long run because it's the responsibility of `Convert-JVString` to cover all use cases, especially when new aggregators are added. At the moment, I don't see a large deviation in ID patterns.

Right now, I think either choice is fine, but I will leave the final decision to you.

What do you think?

Personally, I have gone with the first choice, but if need be, I can implement the second choice.

With that, I've only made changes to DMM as a prototype, but if this proposal is accepted, I will continue to make changes for the others depending on the choice.

Checklist:
- [x] Implement `Id` and `ContentId` for DMM.
- [ ] ~~Implement `ContentId` for all other aggregators~~
