### PR TITLE
2.1.2

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.2]
+
+### Added
+- Setting `sort.format.groupactress` to convert the `<ACTORS>` format string. If enabled:
+    - Multiple actresses => `@Group`
+    - Unknown actress => `@Unknown`
+- `-Strict` parameter is now available during `-Find` usage for R18 scraper only (#125)
+    - R18 scraper does automatic conversion from ContentID => Id which failed for certain movie IDs ( MBR-AA063)
+
+### Fixed
+- Aliases for actresses with a single-word name are now properly replaced by the thumb csv
+- Tags and tagline fields in the nfo now correctly replace invalid xml characters (#124)
+    - Sort no longer fails when trying to download actress images
+- Downloading actress images no longer fails when
+- R18 title metadata is now properly uncensored
+
 ## [2.1.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -452,18 +452,18 @@ For example, if your actress priority looks like this: `"sort.metadata.priority.
 
 ### Metadata Format Strings
 
-- <\ID>
-- <\CONTENTID>
-- <\TITLE>
-- <\RELEASEDATE>
-- <\YEAR>
-- <\STUDIO>
-- <\RUNTIME>
-- <\SET>
-- <\LABEL>
-- <\ACTORS>
-- <\ORIGINALTITLE>
-- <\RESOLUTION> - requires `sort.metadata.nfo.mediainfo` as true
+- \<ID>
+- \<CONTENTID>
+- \<TITLE>
+- \<RELEASEDATE>
+- \<YEAR>
+- \<STUDIO>
+- \<RUNTIME>
+- \<SET>
+- \<LABEL>
+- \<ACTORS>
+- \<ORIGINALTITLE>
+- \<RESOLUTION> - requires `sort.metadata.nfo.mediainfo` as true
 
 ### Actress Thumb Csv
 
@@ -523,7 +523,7 @@ For example, if your jvGenres.csv file looks like this:
 | -------- | ----------- |
 | Blow | Blowjob
 
-- Any scraped genre that equals `Blow` will be replaced with `Blowjob
+- Any scraped genre that equals `Blow` will be replaced with `Blowjob`
 
 ## Settings Information
 
@@ -565,6 +565,7 @@ For example, if your jvGenres.csv file looks like this:
 | `sort.download.posterimg` | Specifies to create the poster image when sorting a movie. Sort.download.thumbimg is required for this to function. | 0, 1
 | `sort.download.screenshotimg` | Specifies to download screenshot images when sorting a movie. | 0, 1
 | `sort.download.trailervid` | Specifies to download the trailer video when sorting a movie. | 0, 1
+| `sort.format.groupactress` | Specifies to convert theformat string for \<ACTORS> when there is more than one actress to "@Group" and if unknown, to "@Unknown". | 0, 1
 | `sort.format.delimiter` | Specifies the delimiter between actresses when using \<ACTORS> in the format string. | Any string value
 | `sort.format.file` | Specifies the format string when renaming a file. | [Format Strings](#Metadata-Format-Strings)
 | `sort.format.folder` | Specifies the format string when creating the folder. | [Format Strings](#Metadata-Format-Strings)

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.1.1'
+    ModuleVersion     = '2.1.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Convert-JVString.ps1
+++ b/src/Javinizer/Private/Convert-JVString.ps1
@@ -20,7 +20,10 @@ function Convert-JVString {
         [Boolean]$ActressLanguageJa,
 
         [Parameter()]
-        [Boolean]$FirstNameOrder
+        [Boolean]$FirstNameOrder,
+
+        [Parameter()]
+        [Boolean]$GroupActress
     )
 
     process {
@@ -88,6 +91,17 @@ function Convert-JVString {
         }
 
         $actresses = ($actressObject | Sort-Object) -join $Delimiter
+
+        if ($GroupActress) {
+            if (($actresses -split $Delimiter).Count -gt 1) {
+                $actresses = '@Group'
+            } elseif ($actresses -match 'Unknown') {
+                $actresses = '@Unknown'
+            }
+        } else {
+            $actresses = ($actressObject | Sort-Object) -join $Delimiter
+        }
+
         $convertedName = $FormatString `
             -replace '<ID>', "$($Data.Id)" `
             -replace '<CONTENTID>', "$($Data.ContentId)" `

--- a/src/Javinizer/Private/Scraper.R18.ps1
+++ b/src/Javinizer/Private/Scraper.R18.ps1
@@ -47,11 +47,9 @@ function Get-R18Title {
         $title = (($Webrequest.Content -split '<cite itemprop=\"name\">')[1] -split '<\/cite>')[0]
         $title = Convert-HtmlCharacter -String $title
         if ($Replace) {
-            foreach ($string in $Replace) {
-                if (($title -split ' ') -eq $string.Original) {
-                    $title = $title -replace [regex]::Escape($string.Original), $string.Replacement
-                    $title = $title -replace '  ', ' '
-                }
+            foreach ($string in $Replace.GetEnumerator()) {
+                $title = $title -replace [regex]::Escape($string.Original), $string.Replacement
+                $title = $title -replace '  ', ' '
             }
         }
 
@@ -250,7 +248,7 @@ function Get-R18Series {
             }
 
             if ($Replace) {
-                foreach ($string in $Replace) {
+                foreach ($string in $Replace.GetEnumerator()) {
                     $series = $series -replace [regex]::Escape($string.Original), $string.Replacement
                 }
             }

--- a/src/Javinizer/Private/Test-JVSettings.ps1
+++ b/src/Javinizer/Private/Test-JVSettings.ps1
@@ -90,6 +90,7 @@ function Test-JVSettings {
             'sort.download.screenshotimg',
             'sort.download.thumbimg',
             'sort.download.trailervid',
+            'sort.format.groupactress',
             'sort.metadata.genrecsv',
             'sort.metadata.nfo.altnamerole',
             'sort.metadata.nfo.actresslanguageja',

--- a/src/Javinizer/Public/Get-DmmUrl.ps1
+++ b/src/Javinizer/Public/Get-DmmUrl.ps1
@@ -4,10 +4,13 @@ function Get-DmmUrl {
     [CmdletBinding()]
     param (
         [Parameter(Position = 0, ValueFromPipeline = $true)]
-        [string]$Id,
+        [String]$Id,
 
         [Parameter()]
-        [string]$r18Url
+        [String]$r18Url,
+
+        [Parameter()]
+        [Switch]$Strict
     )
 
     process {
@@ -18,14 +21,16 @@ function Get-DmmUrl {
             Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$originalId] [$($MyInvocation.MyCommand.Name)] Converting R18 Id to Dmm: [$r18Id] -> [$directUrl]"
         } else {
             # Convert the movie Id (ID-###) to content Id (ID00###) to match dmm naming standards
-            if ($Id -match '([a-zA-Z|tT28|rR18]+-\d+z{0,1}Z{0,1}e{0,1}E{0,1})') {
-                $splitId = $Id -split '-'
-                if (($splitId[1])[-1] -match '\D') {
-                    $appendChar = ($splitId[1])[-1]
-                    $splitId[1] = $splitId[1] -replace '\D', ''
+            if (!($Strict)) {
+                if ($Id -match '([a-zA-Z|tT28|rR18]+-\d+z{0,1}Z{0,1}e{0,1}E{0,1})') {
+                    $splitId = $Id -split '-'
+                    if (($splitId[1])[-1] -match '\D') {
+                        $appendChar = ($splitId[1])[-1]
+                        $splitId[1] = $splitId[1] -replace '\D', ''
+                    }
+                    $Id = $splitId[0] + $splitId[1].PadLeft(5, '0') + $appendChar
+                    $Id = $Id.Trim()
                 }
-                $Id = $splitId[0] + $splitId[1].PadLeft(5, '0') + $appendChar
-                $Id = $Id.Trim()
             }
 
             $searchUrl = "https://www.dmm.co.jp/search/?redirect=1&enc=UTF-8&category=&searchstr=$Id"

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -367,7 +367,7 @@ function Get-JVAggregatedData {
                     # Try three methods for matching aliases
                     # FirstName | FirstName, LastName | JapaneseName
                     for ($x = 0; $x -lt $aggregatedDataObject.Actress.Count; $x++) {
-                        if (($aggregatedDataObject.Actress[$x].LastName -eq '' -and $aggregatedDataObject.Actress[$x].FirstName -ne '') -and ($matched = Compare-Object -ReferenceObject $aliasObject -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('FirstName'))) {
+                        if ((($aggregatedDataObject.Actress[$x].LastName -eq '' -or $null -eq $aggregatedDataObject.Actress[$x].LastName) -and ($aggregatedDataObject.Actress[$x].FirstName -ne '' -and $null -ne $aggregatedDataObject.Actress[$x].FirstName)) -and ($matched = Compare-Object -ReferenceObject $aliasObject -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('FirstName'))) {
                             $aliasString = "$($matched.LastName) $($matched.FirstName)".Trim()
                             if ($matched.Count -eq 1) {
                                 $aggregatedDataObject.Actress[$x].FirstName = $actressCsv[$matched.Index].FirstName
@@ -387,10 +387,10 @@ function Get-JVAggregatedData {
                         } elseif ($matched = Compare-Object -ReferenceObject $aliasObject -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('FirstName', 'LastName')) {
                             $aliasString = "$($matched.LastName) $($matched.FirstName)".Trim()
                             if ($matched.Count -eq 1) {
-                                $aggregatedDataObject.Actress[$x].FirstName = $actressCsv[$matched[0].Index].FirstName
-                                $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched[0].Index].LastName
-                                $aggregatedDataObject.Actress[$x].JapaneseName = $actressCsv[$matched[0].Index].JapaneseName
-                                $aggregatedDataObject.Actress[$x].ThumbUrl = $actressCsv[$matched[0].Index].ThumbUrl
+                                $aggregatedDataObject.Actress[$x].FirstName = $actressCsv[$matched.Index].FirstName
+                                $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched.Index].LastName
+                                $aggregatedDataObject.Actress[$x].JapaneseName = $actressCsv[$matched.Index].JapaneseName
+                                $aggregatedDataObject.Actress[$x].ThumbUrl = $actressCsv[$matched.Index].ThumbUrl
                                 $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Alias - $aliasString] converted to [$actressString] using FirstName LastName match"
                             } elseif ($matched.Count -gt 1) {
@@ -402,7 +402,7 @@ function Get-JVAggregatedData {
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Alias - $aliasString] converted to [$actressString] using FirstName LastName match"
                             }
                         } elseif (($aggregatedDataObject.Actress[$x].JapaneseName -ne '') -and ($matched = Compare-Object -ReferenceObject $aliasObject -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('JapaneseName'))) {
-                            $aliasString = "$($matched.LastName) $($matched.FirstName)".Trim()
+                            $aliasString = "$($matched.JapaneseName)".Trim()
                             if ($matched.Count -eq 1) {
                                 $aggregatedDataObject.Actress[$x].FirstName = $actressCsv[$matched.Index].FirstName
                                 $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched.Index].LastName

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -150,7 +150,12 @@ function Get-JVAggregatedData {
         [String]$IdPreference,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
-        [PSObject]$MediaInfo
+        [Alias('sort.metadata.nfo.mediainfo')]
+        [PSObject]$MediaInfo,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
+        [Alias('sort.format.groupactress')]
+        [Boolean]$GroupActress
     )
 
     process {
@@ -187,6 +192,7 @@ function Get-JVAggregatedData {
             $Tag = $Settings.'sort.metadata.nfo.format.tag'
             $Tagline = $Settings.'sort.metadata.nfo.format.tagline'
             $IdPreference = $Settings.'scraper.option.idpreference'
+            $GroupActress = $Settings.'sort.format.groupactress'
             if ($Settings.'location.genrecsv' -ne '') {
                 $GenreCsvPath = $Settings.'location.genrecsv'
             }
@@ -262,7 +268,7 @@ function Get-JVAggregatedData {
         }
 
         # The displayname value is updated after the previous fields have already been scraped
-        $aggregatedDataObject.DisplayName = Convert-JVString -Data $aggregatedDataObject -FormatString $DisplayNameFormat -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
+        $aggregatedDataObject.DisplayName = Convert-JVString -Data $aggregatedDataObject -FormatString $DisplayNameFormat -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
 
         if ($ThumbCsv) {
             if (Test-Path -LiteralPath $ThumbCsvPath) {
@@ -550,7 +556,7 @@ function Get-JVAggregatedData {
         if ($null -ne $Tag[0]) {
             $aggregatedDataObject.Tag = @()
             foreach ($entry in $Tag) {
-                $tagString = (Convert-JVString -Data $aggregatedDataObject -FormatString $entry -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder)
+                $tagString = (Convert-JVString -Data $aggregatedDataObject -FormatString $entry -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress)
                 if ($null -ne $tagString -and $tagstring -ne '') {
                     $aggregatedDataObject.Tag += $tagString
                 }
@@ -561,7 +567,7 @@ function Get-JVAggregatedData {
         }
 
         if ($Tagline -ne '') {
-            $taglineString = (Convert-JVString -Data $aggregatedDataObject -FormatString $Tagline -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder)
+            $taglineString = (Convert-JVString -Data $aggregatedDataObject -FormatString $Tagline -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress)
             if ($null -ne $taglineString -and $taglineString -ne '') {
                 $aggregatedDataObject.Tagline += $taglineString
             }

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -72,7 +72,10 @@ function Get-JVData {
         [PSObject]$Settings,
 
         [Parameter(ParameterSetName = 'Url')]
-        [PSObject]$Url
+        [PSObject]$Url,
+
+        [Parameter(ParameterSetName = 'Id')]
+        [Switch]$Strict
     )
 
     process {
@@ -125,7 +128,7 @@ function Get-JVData {
 
             if ($R18 -or $R18Zh) {
                 if (!($R18Url -or $R18ZhUrl)) {
-                    $jvR18Url = Get-R18Url -Id $Id
+                    $jvR18Url = Get-R18Url -Id $Id -Strict:$Strict
                 }
                 if ($R18) {
                     Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] [Search - R18] [Url - $R18Url]"
@@ -210,7 +213,7 @@ function Get-JVData {
 
             if ($Dmm -or $DmmJa) {
                 if (!($DmmUrl -or $DmmJaUrl)) {
-                    $jvDmmUrl = Get-DmmUrl -Id $Id
+                    $jvDmmUrl = Get-DmmUrl -Id $Id -Strict:$Strict
                 }
                 if ($Dmm) {
                     Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] [Search - Dmm] [Url - $DmmUrl]"

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -213,7 +213,7 @@ function Get-JVData {
 
             if ($Dmm -or $DmmJa) {
                 if (!($DmmUrl -or $DmmJaUrl)) {
-                    $jvDmmUrl = Get-DmmUrl -Id $Id -Strict:$Strict
+                    $jvDmmUrl = Get-DmmUrl -Id $Id
                 }
                 if ($Dmm) {
                     Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] [Search - Dmm] [Url - $DmmUrl]"

--- a/src/Javinizer/Public/Get-JVNfo.ps1
+++ b/src/Javinizer/Public/Get-JVNfo.ps1
@@ -111,6 +111,7 @@ function Get-JVNfo {
         $Maker = Convert-NfoChar -String $Maker -ErrorAction SilentlyContinue
         $Label = Convert-NfoChar -String $Label -ErrorAction SilentlyContinue
         $Series = Convert-NfoChar -String $Series -ErrorAction SilentlyContinue
+        $Tagline = Convert-NfoChar -String $Tagline -ErrorAction SilentlyContinue
         $releaseYear = ($ReleaseDate -split '-')[0]
 
         $nfoString = @"
@@ -144,6 +145,7 @@ function Get-JVNfo {
         }
 
         foreach ($item in $Tag) {
+            $item = Convert-NfoChar -String $Tag -ErrorAction SilentlyContinue
             $tagNfoString = @"
     <tag>$item</tag>
 

--- a/src/Javinizer/Public/Get-JVNfo.ps1
+++ b/src/Javinizer/Public/Get-JVNfo.ps1
@@ -94,7 +94,7 @@ function Get-JVNfo {
             param (
                 [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
                 [AllowEmptyString()]
-                [String]$String
+                [PSObject]$String
             )
 
             process {

--- a/src/Javinizer/Public/Get-R18Url.ps1
+++ b/src/Javinizer/Public/Get-R18Url.ps1
@@ -4,8 +4,10 @@ function Get-R18Url {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
-        [String]$Id
+        [String]$Id,
 
+        [Parameter()]
+        [Switch]$Strict
     )
 
     process {
@@ -14,15 +16,17 @@ function Get-R18Url {
         $searchUrl = "https://www.r18.com/common/search/searchword=$Id/"
 
         # If contentId is given, convert it back to standard movie ID to validate
-        if ($Id -match '(?:\d{1,5})?([a-zA-Z]{2,10}|[tT]28|[rR]18)(\d{1,5})') {
-            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Content ID [$Id] detected"
-            $splitId = $Id | Select-String -Pattern '([a-zA-Z|tT28|rR18]{1,10})(\d{1,5})'
-            $studioName = $splitId.Matches.Groups[1].Value
-            $rawStudioId = $splitId.Matches.Groups[2].Value
-            $studioIdIndex = ($rawStudioId | Select-String -Pattern '[1-9]').Matches.Index
-            $studioId = ($rawStudioId[$studioIdIndex..($rawStudioId.Length - 1)] -join '').PadLeft(3, '0')
+        if (!($Strict)) {
+            if ($Id -match '(?:\d{1,5})?([a-zA-Z]{2,10}|[tT]28|[rR]18)(\d{1,5})') {
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Content ID [$Id] detected"
+                $splitId = $Id | Select-String -Pattern '([a-zA-Z|tT28|rR18]{1,10})(\d{1,5})'
+                $studioName = $splitId.Matches.Groups[1].Value
+                $rawStudioId = $splitId.Matches.Groups[2].Value
+                $studioIdIndex = ($rawStudioId | Select-String -Pattern '[1-9]').Matches.Index
+                $studioId = ($rawStudioId[$studioIdIndex..($rawStudioId.Length - 1)] -join '').PadLeft(3, '0')
 
-            $Id = "$($studioName.ToUpper())-$studioId"
+                $Id = "$($studioName.ToUpper())-$studioId"
+            }
         }
 
         # Convert the movie Id (ID-###) to content Id (ID00###) to match dmm naming standards

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -284,6 +284,7 @@ function Javinizer {
         [System.IO.FileInfo]$SettingsPath,
 
         [Parameter(ParameterSetName = 'Path')]
+        [Parameter(ParameterSetNAme = 'Info')]
         [Parameter(ParameterSetName = 'Javlibrary')]
         [Switch]$Strict,
 
@@ -533,7 +534,8 @@ function Javinizer {
                     }
                 } else {
                     $data = Get-JVData -Id $Find -R18:$R18 -R18Zh:$R18Zh -Javlibrary:$Javlibrary -JavlibraryJa:$JavlibraryJa -JavlibraryZh:$JavlibraryZh -Dmm:$Dmm `
-                        -DmmJa:$DmmJa -Javbus:$Javbus -JavbusJa:$JavbusJa -JavbusZh:$JavbusZh -Jav321Ja:$Jav321Ja -JavlibraryBaseUrl $Settings.'javlibrary.baseurl' -UncensorCsvPath $uncensorCsvPath
+                        -DmmJa:$DmmJa -Javbus:$Javbus -JavbusJa:$JavbusJa -JavbusZh:$JavbusZh -Jav321Ja:$Jav321Ja -JavlibraryBaseUrl $Settings.'javlibrary.baseurl' `
+                        -UncensorCsvPath $uncensorCsvPath -Strict:$Strict
                 }
 
                 if ($Aggregated) {
@@ -780,7 +782,7 @@ function Javinizer {
                                 $mediaInfo = Get-JVMediaInfo -Path $movie.FullName
                             }
 
-                            $javData = Get-JVData -Id $movie.Id -Settings $Settings -UncensorCsvPath $uncensorCsvPath
+                            $javData = Get-JVData -Id $movie.Id -Settings $Settings -UncensorCsvPath $uncensorCsvPath -Strict:$Strict
                             if ($null -ne $javData) {
                                 $javAggregatedData = $javData | Get-JVAggregatedData -Settings $Settings -MediaInfo $mediaInfo | Test-JVData -RequiredFields $Settings.'sort.metadata.requiredfield'
                                 if ($javAggregatedData.NullFields -eq '') {

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -126,7 +126,11 @@ function Set-JVMovie {
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [Alias('sort.metadata.nfo.altnamerole')]
-        [Boolean]$AltNameRole
+        [Boolean]$AltNameRole,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Alias('sort.format.groupactress')]
+        [Boolean]$GroupActress
     )
 
     begin {
@@ -166,31 +170,31 @@ function Set-JVMovie {
             $ActressLanguageJa = $Settings.'sort.metadata.nfo.actresslanguageja'
             $OriginalPath = $Settings.'sort.metadata.nfo.originalpath'
             $AltNameRole = $Settings.'sort.metadata.nfo.altnamerole'
-
+            $GroupActress = $Settings.'sort.format.groupactress'
         }
 
         if ($RenameFile) {
-            $fileName = Convert-JVString -Data $Data -Format $FileFormat -PartNumber $PartNumber -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
+            $fileName = Convert-JVString -Data $Data -Format $FileFormat -PartNumber $PartNumber -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
         } else {
             $fileName = (Get-Item -LiteralPath $Path).BaseName
         }
         if ($outputFolderFormat -ne '') {
-            $outputFolderName = Convert-JVstring -Data $Data -Format $OutputFolderFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
+            $outputFolderName = Convert-JVstring -Data $Data -Format $OutputFolderFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
         }
-        $folderName = Convert-JVString -Data $Data -Format $FolderFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
-        $thumbName = Convert-JVString -Data $Data -Format $ThumbnailFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
-        $trailerName = Convert-JVString -Data $Data -Format $TrailerFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
-        $screenshotImgName = Convert-JVString -Data $Data -Format $ScreenshotImgFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
-        $screenshotFolderName = Convert-JVString -Data $Data -Format $ScreenshotFolderFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
-        $actorFolderName = Convert-JVString -Data $Data -Format $ActorFolderFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
+        $folderName = Convert-JVString -Data $Data -Format $FolderFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
+        $thumbName = Convert-JVString -Data $Data -Format $ThumbnailFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
+        $trailerName = Convert-JVString -Data $Data -Format $TrailerFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
+        $screenshotImgName = Convert-JVString -Data $Data -Format $ScreenshotImgFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
+        $screenshotFolderName = Convert-JVString -Data $Data -Format $ScreenshotFolderFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
+        $actorFolderName = Convert-JVString -Data $Data -Format $ActorFolderFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
 
         $posterName = @()
         foreach ($format in $PosterFormat) {
-            $posterName += Convert-JVString -Data $Data -Format $format -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
+            $posterName += Convert-JVString -Data $Data -Format $format -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
         }
 
         if ($CreateNfo) {
-            $nfoName = Convert-JVString -Data $Data -Format $NfoFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder
+            $nfoName = Convert-JVString -Data $Data -Format $NfoFormat -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
             if ($CreateNfoPerFile) {
                 $nfoName = $fileName
             }
@@ -221,12 +225,6 @@ function Set-JVMovie {
         if ($Update) {
             $folderPath = (Get-Item -LiteralPath $Path).Directory
         }
-
-        <#         $pathLength = (Join-Path -Path $folderPath -ChildPath $fileName).Length
-        if ($pathLength -gt $MaxPathLength) {
-            Write-Warning "[$(Get-TimeStamp)][$($MyInvocation.MyCommand.Name)] Skipped: [$($DataObject.OriginalFileName)] Folder path length limitations: [$pathLength characters]"
-            continue
-        } #>
 
         if ($Force -or $PSCmdlet.ShouldProcess($Path)) {
             # We do not want to recreate the destination folder if it already exists

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -46,6 +46,7 @@
     "sort.download.posterimg": 1,
     "sort.download.screenshotimg": 0,
     "sort.download.trailervid": 0,
+    "sort.format.groupactress": 1,
     "sort.format.delimiter": ", ",
     "sort.format.file": "<ID>",
     "sort.format.folder": "<ID> [<STUDIO>] - <TITLE> (<YEAR>)",


### PR DESCRIPTION
## [2.1.2]

### Added
- Setting `sort.format.groupactress` to convert the `<ACTORS>` format string. If enabled:
    - Multiple actresses => `@Group`
    - Unknown actress => `@Unknown`
- `-Strict` parameter is now available during `-Find` usage for R18 scraper only (#125)
    - R18 scraper does automatic conversion from ContentID => Id which failed for certain movie IDs ( MBR-AA063)

### Fixed
- Aliases for actresses with a single-word name are now properly replaced by the thumb csv
- Tags and tagline fields in the nfo now correctly replace invalid xml characters (#124)
    - Sort no longer fails when trying to download actress images
- Downloading actress images no longer fails when
- R18 title metadata is now properly uncensored