### PR TITLE
Fixed genre for jav321 resulting in null values

### DIFF
--- a/src/Javinizer/Private/Scraper.Jav321.ps1
+++ b/src/Javinizer/Private/Scraper.Jav321.ps1
@@ -118,9 +118,8 @@ function Get-Jav321Genre {
         $genre = @()
 
         try {
-            $genre = ($Webrequest | ForEach-Object { $_ -split '\n' } |
-                Select-String '<a href="\/genre\/(.*)\/(.*)">(.*)<\/a> ').Matches.Groups[0] -split '<\/a>' |
-            ForEach-Object { ($_ -split '>')[1] }
+            $genre = ($Webrequest | Select-String '<a href="\/genre\/.+?">(.+?)<\/a>' -AllMatches).Matches |
+                ForEach-Object { $_.Groups[1].Value }
         } catch {
             return
         }


### PR DESCRIPTION
When scraping jav321 with multiple genres, the scraper returns an array of genres with the last element being `null`.

This PR fixes the aforementioned problem with regex.