### PR TITLE
2.2.4

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.4]
+
+### Fixed
+
+-   JAVLibrary scraper now works correctly with b49t.com mirror
+-   Get-CfSession function now successfully accepts the \_\_cfduid, cf_clearance, and browser useragent when scraping from cloudflare protected JAVLibrary site
+-   Dynamic directory names with trailing periods are now trimmed to resolve terminating error during sort (Thanks @amdishigh)
+-   Japanese actress names are now correctly added to the format string when `sort.metadata.nfo.actresslanguageja` is true (Thanks @amdishigh)
+
 ## [2.2.3]
 
 ### Fixed

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.2.3'
+    ModuleVersion     = '2.2.4'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Convert-JVString.ps1
+++ b/src/Javinizer/Private/Convert-JVString.ps1
@@ -89,7 +89,7 @@ function Convert-JVString {
 
         $actressObject = @()
         if ($ActressLanguageJa) {
-            if ($null -ne $Data.Actress.Japanese) {
+            if ($null -ne $Data.Actress.JapaneseName) {
                 $actressObject = $Data.Actress.JapaneseName
             } elseif ($FirstNameOrder) {
                 foreach ($actress in $Data.Actress) {

--- a/src/Javinizer/Private/Get-JVUrlLocation.ps1
+++ b/src/Javinizer/Private/Get-JVUrlLocation.ps1
@@ -2,7 +2,10 @@ function Get-JVUrlLocation {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
-        [PSObject]$Url
+        [PSObject]$Url,
+
+        [Parameter()]
+        [PSObject]$Settings
     )
 
     process {
@@ -20,7 +23,7 @@ function Get-JVUrlLocation {
                         Source = 'r18'
                     }
                 }
-            } elseif ($link -match 'javlibrary.com' -or $link -match 'g46e.com' -or $link -match 'm45e.com') {
+            } elseif ($link -match 'javlibrary.com' -or $link -match 'g46e.com' -or $link -match 'm45e.com' -or $link -or $link -match ($Settings.'javlibrary.baseurl' -replace 'http(s)?:\/\/')) {
                 if ($link -match '/ja/') {
                     $testUrlObject += [PSCustomObject]@{
                         Url    = $link

--- a/src/Javinizer/Public/Get-CfSession.ps1
+++ b/src/Javinizer/Public/Get-CfSession.ps1
@@ -15,12 +15,14 @@ function Get-CfSession {
     )
 
     process {
+        $BaseUrl = $BaseUrl -replace 'http(s)?:\/\/(www)?'
         $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
         $cookie = New-Object System.Net.Cookie('__cfduid', "$Cfduid", '/', "$BaseUrl")
         $session.Cookies.Add($cookie)
         $cookie = New-Object System.Net.Cookie('cf_clearance', "$Cfclearance", '/', "$BaseUrl")
         $session.Cookies.Add($cookie)
         $session.UserAgent = $UserAgent
+
         Write-Output $session
     }
 }

--- a/src/Javinizer/Public/Get-JVData.ps1
+++ b/src/Javinizer/Public/Get-JVData.ps1
@@ -103,7 +103,7 @@ function Get-JVData {
         $Id = $Id.ToUpper()
 
         if ($Url) {
-            $urlObject = $Url | Get-JVUrlLocation
+            $urlObject = $Url | Get-JVUrlLocation -Settings $Settings
         } elseif ($Settings) {
             $R18 = $Settings.'scraper.movie.r18'
             $R18Zh = $Settings.'scraper.movie.r18zh'

--- a/src/Javinizer/Public/Get-JavlibraryUrl.ps1
+++ b/src/Javinizer/Public/Get-JavlibraryUrl.ps1
@@ -76,7 +76,7 @@ function Get-JavlibraryUrl {
                     Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$Id] [$($MyInvocation.MyCommand.Name)] Result [$count] is [$resultId]"
 
                     if ($resultId -eq $Id) {
-                        $javlibraryUrl = (Get-JVUrlLocation -Url $webRequest.BaseResponse.RequestMessage.RequestUri.AbsoluteUri).Url
+                        $javlibraryUrl = $directUrl
                         break
                     }
 

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -584,7 +584,7 @@ function Javinizer {
         switch ($PsCmdlet.ParameterSetName) {
             'Info' {
                 if ($Find -match 'https?:\/\/') {
-                    $urlObject = Get-JVUrlLocation -Url $Find
+                    $urlObject = Get-JVUrlLocation -Url $Find -Settings $Settings
                     $data = foreach ($item in $urlObject) {
                         if ($item.Source -match 'dmm') {
                             $item.Url | Get-DmmData -ScrapeActress:$Settings.'scraper.option.dmm.scrapeactress'

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -235,6 +235,9 @@ function Set-JVMovie {
         }
 
         if ($Force -or $PSCmdlet.ShouldProcess($Path)) {
+            # Windows directory paths do not allow trailing dots/periods but do not throw an error on creation
+            $folderPath = $folderPath.TrimEnd('.')
+
             # We do not want to recreate the destination folder if it already exists
             try {
                 if (!(Test-Path -LiteralPath $folderPath) -and (!($Update))) {
@@ -469,13 +472,13 @@ function Set-JVMovie {
                                 } elseif ([System.Environment]::OSVersion.Platform -eq 'Unix') {
                                     if ($Force) {
                                         try {
-                                            mv $Path $filePath --force
+                                            Move-Item $Path $filePath --force
                                         } catch {
                                             Move-Item -LiteralPath $Path -Destination $filePath -Force
                                         }
                                     } else {
                                         try {
-                                            mv $Path $filePath --no-clobber
+                                            Move-Item $Path $filePath --no-clobber
                                         } catch {
                                             Move-Item -LiteralPath $Path -Destination $filePath
                                         }
@@ -504,13 +507,13 @@ function Set-JVMovie {
                                     } elseif ([System.Environment]::OSVersion.Platform -eq 'Unix') {
                                         if ($Force) {
                                             try {
-                                                mv $Path $filePath --force
+                                                Move-Item $Path $filePath --force
                                             } catch {
                                                 Move-Item -LiteralPath $Path -Destination $filePath -Force
                                             }
                                         } else {
                                             try {
-                                                mv $Path $filePath --no-clobber
+                                                Move-Item $Path $filePath --no-clobber
                                             } catch {
                                                 Move-Item -LiteralPath $Path -Destination $filePath
                                             }


### PR DESCRIPTION
## [2.2.4]

### Fixed

-   JAVLibrary scraper now works correctly with b49t.com mirror
-   Get-CfSession function now successfully accepts the \_\_cfduid, cf_clearance, and browser useragent when scraping from cloudflare protected JAVLibrary site
-   Dynamic directory names with trailing periods are now trimmed to resolve terminating error during sort (Thanks @amdishigh)
-   Japanese actress names are now correctly added to the format string when `sort.metadata.nfo.actresslanguageja` is true (Thanks @amdishigh)