### PR TITLE
2.2.5

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.5]
+
+### Fixed
+
+-   Fix breaking error causing sort to fail when trimming trailing periods on folder paths
+
 ## [2.2.4]
 
 ### Fixed

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.2.4'
+    ModuleVersion     = '2.2.5'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -236,7 +236,7 @@ function Set-JVMovie {
 
         if ($Force -or $PSCmdlet.ShouldProcess($Path)) {
             # Windows directory paths do not allow trailing dots/periods but do not throw an error on creation
-            $folderPath = $folderPath.TrimEnd('.')
+            $folderPath = ([String]$folderPath).TrimEnd('.')
 
             # We do not want to recreate the destination folder if it already exists
             try {


### PR DESCRIPTION
## [2.2.5]

### Fixed

-   Fix breaking error causing sort to fail when trimming trailing periods on folder paths
