### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 umask 000
-/bin/bash
 /home/Universal/Universal.Server


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Removing /bin/bash/ on line 3 allows a docker container to be launched directly from the Docker GUI on Synology, instead of having to do a docker run command via SSH. I tested it by doing a container build with the only change being this line removed. The test image is available on Docker Hub at: thewhitedoll/javinizertest

I believe the #!/bin/bash shebang makes having /bin/bash in the script again redundant, and is what's causing the issue.

I'm not entirely sure why this is an issue with the Docker GUI on Synology, but not the command line.
## Related Issue
Discussed on the Discussions page.

## Motivation and Context
This makes it easier for Synology users to be able to use Javinizer, especially if they are not comfortable with command line.

## How Has This Been Tested?
I built a Javinizer container with only this change, pushed it to Docker Hub, and launched it sucessfully from the Docker GUI on Synology.

## Types of changes
Removes one line.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

