### PR TITLE
2.2.9

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.2.8]
+## [2.2.9]
+
+### Added
+
+-   Added setting `sort.metadata.genrecsv.autoadd` to automatically add unknown genres to the genre csv file (#181)
+    -   `sort.metadata.genrecsv` functionality has been updated to ignore genres with a null `Replacement` value
+-   Added setting `sort.metadata.nfo.translate.keeporiginaldescription` to append the original description to the translated one (#182)
+
+### Changed
+
+-   Changed default Javinizer GUI (PowerShell Universal) web port to 8600 to alleviate conflicts with Synology NAS ports
+-   `-OpenGUI` now checks for a valid Javinizer dashboard and self-fixes if missing
+
+### Fixed
+
+-   Fixed the `-Url` parameter defaulting to JavLibrary detection when sorting manually with urls
+-   Fixed JavLibrary actress scraper not capturing Japanese names when using a mirror site
 
 ### Added
 
@@ -13,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     -   `Javinizer -InstallGUI`
     -   `Javinizer -OpenGUI`
 
-## [2.2.5]
+## [2.2.8]
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM ubuntu:18.04
 
 ADD docker-entrypoint.sh /home/
+ADD src/Javinizer/Universal/Repository/javinizergui.ps1 /home/
 RUN chmod +x /home/docker-entrypoint.sh
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update -y && apt-get install -y curl unrar wget software-properties-common apt-transport-https
@@ -24,17 +25,16 @@ RUN apt-get update -y
 RUN apt-get install -y python3.8 python3-pip
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
 RUN pip3 install pillow google_trans_new googletrans==4.0.0rc1
-RUN apt-get install -y git
 
 # Add custom UD components
 RUN pwsh -Command "Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted"
 RUN pwsh -Command "Install-Module UniversalDashboard.Style; Install-Module UniversalDashboard.UDPlayer; Install-Module UniversalDashboard.UDSpinner; Install-Module UniversalDashboard.UDScrollUp; Install-Module UniversalDashboard.CodeEditor"
+RUN pwsh -Command "Install-Module Javinizer"
 
-# Clone Javinizer master branch
-WORKDIR /home
-RUN git clone https://github.com/jvlflame/Javinizer.git
 
-EXPOSE 5000
+
+WORKDIR /
+EXPOSE 8600
 VOLUME ["/data"]
 ENV Data__RepositoryPath ./data/Repository
 ENV Data__ConnectionString ./data/database.db

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.2.8'
+    ModuleVersion     = '2.2.9'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Get-JVUrlLocation.ps1
+++ b/src/Javinizer/Private/Get-JVUrlLocation.ps1
@@ -23,7 +23,7 @@ function Get-JVUrlLocation {
                         Source = 'r18'
                     }
                 }
-            } elseif ($link -match 'javlibrary.com' -or $link -match 'g46e.com' -or $link -match 'm45e.com' -or $link -or $link -match ($Settings.'javlibrary.baseurl' -replace 'http(s)?:\/\/')) {
+            } elseif ($link -match 'javlibrary.com' -or $link -match 'g46e.com' -or $link -match 'm45e.com' -or $link -match ($Settings.'javlibrary.baseurl' -replace 'http(s)?:\/\/')) {
                 if ($link -match '/ja/') {
                     $testUrlObject += [PSCustomObject]@{
                         Url    = $link

--- a/src/Javinizer/Private/Scraper.Javlibrary.ps1
+++ b/src/Javinizer/Private/Scraper.Javlibrary.ps1
@@ -196,7 +196,7 @@ function Get-JavlibraryActress {
             process {
                 try {
                     $movieActress = ($Webrequest.Content | Select-String -Pattern '<a href="vl_star\.php\?s=(?:.*)" rel="tag">(.*)<\/a><\/span>').Matches.Groups[0].Value `
-                        -split '<span class="star">' | ForEach-Object { ($_ | Select-String -Pattern '<a href="vl_star\.php\?s=(.*)" rel="tag">(.*)<\/a><\/span>').Matches } | ForEach-Object { $_.Groups[2].Value}
+                        -split '<span class="star">' | ForEach-Object { ($_ | Select-String -Pattern '<a href="vl_star\.php\?s=(.*)" rel="tag">(.*)<\/a><\/span>').Matches } | ForEach-Object { $_.Groups[2].Value }
                 } catch {
                     return
                 }
@@ -207,10 +207,10 @@ function Get-JavlibraryActress {
 
         $movieActressObject = @()
         $movieActress = @()
-        $enActressUrl = $Url -replace 'javlibrary.com\/(en|ja|cn|tw|)\/', 'javlibrary.com/en/'
-        $jaActressUrl = $Url -replace 'javlibrary.com\/(en|ja|cn|tw|)\/', 'javlibrary.com/ja/'
+        $enActressUrl = $Url -replace '.com\/(en|ja|cn|tw|)\/', '.com/en/'
+        $jaActressUrl = $Url -replace '.com\/(en|ja|cn|tw|)\/', '.com/ja/'
 
-        if ($Url -match 'javlibrary.com\/en\/') {
+        if ($Url -match '.com\/en\/') {
             $jaWebrequest = Invoke-WebRequest -Uri $jaActressUrl -Method Get -WebSession:$Session -UserAgent:$Session.UserAgent -Verbose:$false
             $enActress = Get-Actress -Webrequest $Webrequest
             $jaActress = Get-Actress -Webrequest $jaWebrequest

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -132,6 +132,10 @@ function Get-JVAggregatedData {
         [String]$TranslateLanguage,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
+        [Alias('sort.metadata.nfo.translate.keeporiginaldescription')]
+        [String]$KeepOriginalDescription,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
         [Alias('sort.format.delimiter')]
         [String]$DelimiterFormat,
 
@@ -199,6 +203,7 @@ function Get-JVAggregatedData {
             $Translate = $Settings.'sort.metadata.nfo.translate'
             $TranslateFields = $Settings.'sort.metadata.nfo.translate.field'
             $TranslateLanguage = $Settings.'sort.metadata.nfo.translate.language'
+            $KeepOriginalDescription = $Settings.'sort.metadata.nfo.translate.keeporiginaldescription'
             $DelimiterFormat = $Settings.'sort.format.delimiter'
             $ActressLanguageJa = $Settings.'sort.metadata.nfo.actresslanguageja'
             $ThumbCsvAutoAdd = $Settings.'sort.metadata.thumbcsv.autoadd'
@@ -617,6 +622,13 @@ function Get-JVAggregatedData {
                         if ($null -ne $_.Value -and ($_.Value).Trim() -ne '') {
                             if ($_.Name -eq 'Genre') {
                                 $aggregatedDataObject."$($_.Name)" = $genres
+                            } elseif ($_.Name -eq 'Description') {
+                                if ($KeepOriginalDescription) {
+                                    $description = ($_.Value).Trim() + "`n`n" + $aggregatedDataObject."$($_.Name)"
+                                    $aggregatedDataObject."$($_.Name)" = $description
+                                } else {
+                                    $aggregatedDataObject."$($_.Name)" = ($_.Value).Trim()
+                                }
                             } else {
                                 $aggregatedDataObject."$($_.Name)" = ($_.Value).Trim()
                             }

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -100,6 +100,10 @@ function Get-JVAggregatedData {
         [Boolean]$ReplaceGenre,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
+        [Alias('sort.metadata.genrecsv.autoadd')]
+        [Boolean]$GenreCsvAutoAdd,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
         [Alias('location.genrecsv')]
         [System.IO.FileInfo]$GenreCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvGenres.csv'),
 
@@ -198,6 +202,7 @@ function Get-JVAggregatedData {
             $DelimiterFormat = $Settings.'sort.format.delimiter'
             $ActressLanguageJa = $Settings.'sort.metadata.nfo.actresslanguageja'
             $ThumbCsvAutoAdd = $Settings.'sort.metadata.thumbcsv.autoadd'
+            $GenreCsvAutoAdd = $Settings.'sort.metadata.genrecsv.autoadd'
             $FirstNameOrder = $Settings.'sort.metadata.nfo.firstnameorder'
             $UnknownActress = $Settings.'sort.metadata.nfo.unknownactress'
             $Tag = $Settings.'sort.metadata.nfo.format.tag'
@@ -519,6 +524,33 @@ function Get-JVAggregatedData {
             }
         }
 
+        if ($GenreCsvAutoAdd) {
+            $newGenres = @()
+            if (Test-Path -LiteralPath $GenreCsvPath) {
+                try {
+                    $replaceGenres = Import-Csv -LiteralPath $GenreCsvPath
+                } catch {
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] Error occurred when importing genre csv [$GenreCsvPath]: $PSItem"
+                }
+
+                $currentGenres = $aggregatedDataObject.Genre
+
+                foreach ($genre in $currentGenres) {
+                    if ($genre -notin $replaceGenres.Original) {
+                        $newGenres += [PSCustomObject]@{
+                            Original    = $genre
+                            Replacement = ''
+                        }
+                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Genre - $($genre)] added as a new genre"
+                    }
+                }
+
+                $newGenres | Export-Csv -LiteralPath $GenreCsvPath -Append
+            } else {
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] Genre csv file is missing or cannot be found at path [$grenreCsvPath]"
+            }
+        }
+
         if ($ReplaceGenre) {
             if (Test-Path -LiteralPath $GenreCsvPath) {
                 try {
@@ -530,8 +562,10 @@ function Get-JVAggregatedData {
                 $newGenres = $aggregatedDataObject.Genre
                 foreach ($genrePair in $replaceGenres) {
                     if ($($genrePair.Original -in $newGenres)) {
-                        $newGenres = $newGenres -replace "$($genrePair.Original)", "$($genrePair.Replacement)"
-                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Genre - $($genrePair.Original)] replaced as [$($genrePair.Replacement)]"
+                        if ($genrePair.Replacement -ne '' -and $null -ne $genrePair.Repalcement) {
+                            $newGenres = $newGenres -replace "$($genrePair.Original)", "$($genrePair.Replacement)"
+                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Genre - $($genrePair.Original)] replaced as [$($genrePair.Replacement)]"
+                        }
                     }
                 }
 

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -443,6 +443,9 @@ function Javinizer {
         try {
             if (!($SettingsPath)) {
                 $SettingsPath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvSettings.json'
+            } else {
+                # We need to get the full path of the SettingsPath to define it in the runspaces otherwise relative paths will fail
+                $SettingsPath = (Get-Item -Path $SettingsPath).FullName
             }
             $Settings = Get-Content -LiteralPath $SettingsPath | ConvertFrom-Json -Depth 32
         } catch {

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -432,7 +432,7 @@ function Javinizer {
 
         [Parameter(ParameterSetName = 'Gui')]
         [ValidateRange(0, 65353)]
-        [Int]$Port = 5000
+        [Int]$Port = 8600
     )
 
     process {

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -452,6 +452,33 @@ function Javinizer {
             Write-Error -Message "[$($MyInvocation.MyCommand.Name)] Error occurred when loading settings file [$SettingsPath]: $PSItem" -ErrorAction Stop
         }
 
+        if ($PSBoundParameters.ContainsKey('MoveToFolder')) {
+            if ($MoveToFolder -eq $true) {
+                $Settings.'sort.movetofolder' = 1
+            } elseif ($MoveToFolder -eq $false) {
+                $Settings.'sort.movetofolder' = 0
+            }
+        }
+
+        if ($PSBoundParameters.ContainsKey('RenameFile')) {
+            if ($RenameFile -eq $true) {
+                $Settings.'sort.renamefile' = 1
+            } elseif ($RenameFile -eq $false) {
+                $Settings.'sort.renamefile' = 0
+            }
+        }
+
+        if ($Set) {
+            try {
+                foreach ($item in $Set.GetEnumerator()) {
+                    $Settings."$($item.Key)" = $item.Value
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] [Setting - $($item.Key)] replaced as [$($item.Value)]"
+                }
+            } catch {
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Error occurred when defining settings using -Set: $PSItem"
+            }
+        }
+
         if ($Settings.'admin.log' -eq '1') {
             if ($Settings.'location.log' -eq '') {
                 $script:JVLogPath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvLog.log'
@@ -509,33 +536,6 @@ function Javinizer {
                 return
             } else {
                 $uncensorCsvPath = $Settings.'location.uncensorcsv'
-            }
-        }
-
-        if ($PSBoundParameters.ContainsKey('MoveToFolder')) {
-            if ($MoveToFolder -eq $true) {
-                $Settings.'sort.movetofolder' = 1
-            } elseif ($MoveToFolder -eq $false) {
-                $Settings.'sort.movetofolder' = 0
-            }
-        }
-
-        if ($PSBoundParameters.ContainsKey('RenameFile')) {
-            if ($RenameFile -eq $true) {
-                $Settings.'sort.renamefile' = 1
-            } elseif ($RenameFile -eq $false) {
-                $Settings.'sort.renamefile' = 0
-            }
-        }
-
-        if ($Set) {
-            try {
-                foreach ($item in $Set.GetEnumerator()) {
-                    $Settings."$($item.Key)" = $item.Value
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($MyInvocation.MyCommand.Name)] [Setting - $($item.Key)] replaced as [$($item.Value)]"
-                }
-            } catch {
-                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Error occurred when defining settings using -Set: $PSItem"
             }
         }
 

--- a/src/Javinizer/Public/Start-JVGui.ps1
+++ b/src/Javinizer/Public/Start-JVGui.ps1
@@ -3,7 +3,7 @@ function Start-JVGui {
     param (
         [Parameter(Position = 0)]
         [ValidateRange(0, 65353)]
-        [Int]$Port = 5000
+        [Int]$Port = 8600
     )
 
     $jvModulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation
@@ -11,8 +11,22 @@ function Start-JVGui {
     $jvPsuExePath = Join-Path -Path $jvPsuPath -ChildPath 'Universal.Server.exe'
     $jvPsuSettingsPath = Join-Path -Path $jvPsuPath -ChildPath 'appsettings.json'
     $jvPsuRepositoryPath = Join-Path -Path $jvModulePath -ChildPath 'Universal' -AdditionalChildPath 'Repository'
+    $jvDashboardPath = Join-Path -Path $jvPsuRepositoryPath -ChildPath 'javinizergui.ps1'
     $jvPsuDatabasePath = Join-Path -Path $jvModulePath -ChildPath 'Universal' -AdditionalChildPath 'database.db'
     $jvPsuAssetsFolderPath = Join-Path -Path $jvModulePath -ChildPath 'Universal' -AdditionalChildPath 'Dashboard'
+
+    # Check if the dashboard file is valid
+    $dashboardContent = Get-Content -Path $jvDashboardPath -Raw
+
+    if ($dashboardContent -notmatch 'Javinizer Web') {
+        Write-Warning "Javinizer dashboard content is invalid, redownloading..."
+        try {
+            $origDashboardContent = Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/jvlflame/Javinizer/master/src/Javinizer/Universal/Repository/javinizergui.ps1' -Verbose:$false
+            Set-Content -Path $jvDashboardPath -Value $origDashboardContent -Force -
+        } catch {
+            Write-Error "Error occurred when resetting Javinizer dashboard: $PSItem"
+        }
+    }
 
     # Customize the default appsettings.json for Javinizer specific usage
     $jvPsuSettings = Get-Content -Path $jvPsuSettingsPath | ConvertFrom-Json -Depth 32

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -719,7 +719,7 @@ $Pages += New-UDPage -Name "Sort" -Content {
                                     if ($null -ne $cache:findData[$cache:index].Data.TrailerUrl) {
                                         New-UDButton -Icon $iconVideo -Text 'Trailer' -Size small -FullWidth -OnClick {
                                             Show-UDModal -FullWidth -MaxWidth lg -Content {
-                                                New-UDPlayer -URL $cache:findData[$cache:index].Data.TrailerUrl -Width '550px'
+                                                New-UDPlayer -Url $cache:findData[$cache:index].Data.TrailerUrl -Width '550px'
                                             }
                                         }
                                     }
@@ -1971,7 +1971,8 @@ $Pages += New-UDPage -Name "Settings" -Content {
         'sort.metadata.thumbcsv',
         'sort.metadata.thumbcsv.autoadd',
         'sort.metadata.thumbcsv.convertalias',
-        'sort.metadata.genrecsv'
+        'sort.metadata.genrecsv',
+        'sort.metadata.genrecsv.autoadd'
     )
 
     $translateLanguages = @(
@@ -2079,9 +2080,11 @@ $Pages += New-UDPage -Name "Settings" -Content {
                                 $cache:settings.'match.regex.idmatch' = (Get-UDElement -Id 'textbox-settings-regexidmatch').value
                                 $cache:settings.'match.regex.ptmatch' = (Get-UDElement -Id 'textbox-settings-regexptmatch').value
                                 $cache:settings.'sort.maxtitlelength' = [Int](Get-UDElement -Id 'autocomplete-settings-maxtitlelength').value
+                                $cache:settings.'sort.metadata.nfo.translate' = (Get-UDElement -Id 'checkbox-settings-translate').checked
                                 $cache:settings.'sort.metadata.nfo.translate.language' = (Get-UDElement -Id 'autocomplete-settings-translatelanguage').value
                                 $cache:settings.'sort.metadata.nfo.translate.module' = (Get-UDElement -Id 'autocomplete-settings-translatemodule').value
                                 $cache:settings.'sort.metadata.nfo.translate.field' = ((Get-UDElement -Id 'textbox-settings-translatefield').value -split '\\').Trim()
+                                $cache:settings.'sort.metadata.nfo.translate.keeporiginaldescription' = (Get-UDElement -Id 'checkbox-settings-translate-originaldescription').checked
                                 $cache:settings.'admin.log' = (Get-UDElement -Id 'checkbox-settings-adminlog').checked
                                 $cache:settings.'admin.log.level' = (Get-UDElement -Id 'autocomplete-settings-adminloglevel').value
                                 $cache:settings | ConvertTo-Json | Out-File $cache:settingsPath
@@ -2325,11 +2328,15 @@ $Pages += New-UDPage -Name "Settings" -Content {
                 New-UDCard -Title 'Translate' -Content {
                     New-UDGrid -Container -Content {
                         New-UDGrid -Item -ExtraSmallSize 12 -SmallSize 12 -MediumSize 6 -Content {
-                            New-UDCheckBox -Label 'sort.metadata.nfo.translate' -Id 'sort.metadata.nfo.translate' -LabelPlacement end -Checked ($cache:settings.'sort.metadata.nfo.translate')
+                            New-UDCheckBox -Label 'sort.metadata.nfo.translate' -Id 'checkbox-settings-translate' -LabelPlacement end -Checked ($cache:settings.'sort.metadata.nfo.translate')
                         }
 
                         New-UDGrid -Item -ExtraSmallSize 12 -SmallSize 12 -MediumSize 6 -Content {
                             New-UDTextbox -Placeholder 'sort.metadata.nfo.translate.field' -Id 'textbox-settings-translatefield' -Value ($cache:settings.'sort.metadata.nfo.translate.field' -join ' \ ') -FullWidth
+                        }
+
+                        New-UDGrid -Item -ExtraSmallSize 12 -SmallSize 12 -MediumSize 6 -Content {
+                            New-UDCheckBox -Label 'sort.metadata.nfo.translate.keeporiginaldescription' -Id 'checkbox-settings-translate-originaldescription' -LabelPlacement end -Checked ($cache:settings.'sort.metadata.nfo.translate')
                         }
 
                         New-UDGrid -Item -ExtraSmallSize 12 -SmallSize 12 -MediumSize 6 -Content {

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -80,6 +80,7 @@
     "sort.metadata.thumbcsv.autoadd": true,
     "sort.metadata.thumbcsv.convertalias": true,
     "sort.metadata.genrecsv": false,
+    "sort.metadata.genrecsv.autoadd": false,
     "sort.metadata.genre.ignore": ["^Featured Actress", "^Hi-Def", ".*sale.*"],
     "sort.metadata.requiredfield": ["id", "coverurl", "genre", "maker", "releaseDate", "title"],
     "sort.metadata.priority.actress": ["r18", "javlibrary", "javbus", "mgstageja", "aventertainment"],

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -68,7 +68,7 @@
     "sort.metadata.nfo.translate.module": "googletrans",
     "sort.metadata.nfo.translate.field": ["description"],
     "sort.metadata.nfo.translate.language": "en",
-    "sort.metadata.nfo.translate.keeporiginal": true,
+    "sort.metadata.nfo.translate.keeporiginaldescription": true,
     "sort.metadata.nfo.displayname": "[<ID>] <TITLE>",
     "sort.metadata.nfo.firstnameorder": false,
     "sort.metadata.nfo.actresslanguageja": false,

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -68,6 +68,7 @@
     "sort.metadata.nfo.translate.module": "googletrans",
     "sort.metadata.nfo.translate.field": ["description"],
     "sort.metadata.nfo.translate.language": "en",
+    "sort.metadata.nfo.translate.keeporiginal": true,
     "sort.metadata.nfo.displayname": "[<ID>] <TITLE>",
     "sort.metadata.nfo.firstnameorder": false,
     "sort.metadata.nfo.actresslanguageja": false,


### PR DESCRIPTION
### Added

-   Added setting `sort.metadata.genrecsv.autoadd` to automatically add unknown genres to the genre csv file (#181)
    -   `sort.metadata.genrecsv` functionality has been updated to ignore genres with a null `Replacement` value
-   Added setting `sort.metadata.nfo.translate.keeporiginaldescription` to append the original description to the translated one (#182)

### Changed

-   Changed default Javinizer GUI (PowerShell Universal) web port to 8600 to alleviate conflicts with Synology NAS ports
-   `-OpenGUI` now checks for a valid Javinizer dashboard and self-fixes if missing

### Fixed

-   Fixed the `-Url` parameter defaulting to JavLibrary detection when sorting manually with urls
-   Fixed JavLibrary actress scraper not capturing Japanese names when using a mirror site