### PR TITLE
2.2.10

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.10]
+
+### Added
+
+-   Added `-Preview` parameter to display file matcher details
+-   Added `-OutSettings` parameter to passthru Javinizer settings object to shell
+-   Added `admin.updates.check` setting to check for module updates on first run
+-   **Experimental** Added `-UpdateModule` parameter to perform Javinizer module update with settings persistence
+
+### Fixed
+
+-   `sort.metadata.nfo.translate.keeporiginaldescription` no longer fails to check true/false value
+-   Using `-Update` will no longer recreate the nfo file with a filename title
+-   Directories with a file extension appended to the path name will no longer be detected as a movie
+
 ## [2.2.9]
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 
 FROM ubuntu:18.04
 
-ADD docker-entrypoint.sh /home/
-ADD src/Javinizer/Universal/Repository/javinizergui.ps1 /home/
+ADD docker-entrypoint.sh /home
+ADD src/Javinizer/Universal/Repository/javinizergui.ps1 /home
 RUN chmod +x /home/docker-entrypoint.sh
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update -y && apt-get install -y curl unrar wget software-properties-common apt-transport-https
@@ -31,9 +31,7 @@ RUN pwsh -Command "Set-PSRepository -Name 'PSGallery' -InstallationPolicy Truste
 RUN pwsh -Command "Install-Module UniversalDashboard.Style; Install-Module UniversalDashboard.UDPlayer; Install-Module UniversalDashboard.UDSpinner; Install-Module UniversalDashboard.UDScrollUp; Install-Module UniversalDashboard.CodeEditor"
 RUN pwsh -Command "Install-Module Javinizer"
 
-
-
-WORKDIR /
+WORKDIR /home
 EXPOSE 8600
 VOLUME ["/data"]
 ENV Data__RepositoryPath ./data/Repository

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.2.9'
+    ModuleVersion     = '2.2.10'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')
@@ -74,6 +74,7 @@
         'Invoke-JVParallel',
         'Javinizer',
         'Get-CfSession',
+        'Get-DLgetchuData',
         'Get-DmmData',
         'Get-DmmUrl',
         'Get-Jav321Data',
@@ -86,11 +87,18 @@
         'Get-JVData',
         'Get-JVItem',
         'Get-JVNfo',
+        'Get-JVSettings',
         'Get-JVSortData',
+        'Get-MgstageData',
+        'Get-MgstageUrl',
         'Get-R18Data',
         'Get-R18Url',
+        'Install-JVGui',
+        'Set-JavlibraryOwned',
         'Set-JVEmbyThumbs',
         'Set-JVMovie',
+        'Start-JVGUI',
+        'Update-JVModule',
         'Update-JVThumbCsv',
         'Write-JVWebLog'
     )

--- a/src/Javinizer/Private/Get-JVModuleInfo.ps1
+++ b/src/Javinizer/Private/Get-JVModuleInfo.ps1
@@ -1,0 +1,31 @@
+function Get-JVModuleInfo {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [String]$ModuleManifestUrl
+    )
+
+    begin {
+        if ($PSBoundParameters.ContainsKey('ModuleManifestUrl')) {
+            try {
+                $moduleManifest = Invoke-RestMethod -Uri $ModuleManifestUrl -Verbose:$false
+            } catch {
+                Write-Error "Error occurred when checking for new version: $PSItem" -ErrorAction Stop
+            }
+        } else {
+            $moduleManifest = Get-Content -LiteralPath (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'Javinizer.psd1')
+        }
+    }
+
+    process {
+        $moduleInfo = [PSCustomObject]@{
+            Version      = ($moduleManifest | Select-String -Pattern "ModuleVersion\s*= '(.*)'").Matches.Groups[1].Value
+            Prerelease   = ($moduleManifest | Select-String -Pattern "Prerelease\s*= '(.*)'").Matches.Groups[1].Value
+            Project      = ($moduleManifest | Select-String -Pattern "ProjectUri\s*= '(.*)'").Matches.Groups[1].Value
+            License      = ($moduleManifest | Select-String -Pattern "LicenseUri\s*= '(.*)'").Matches.Groups[1].Value
+            ReleaseNotes = ($moduleManifest | Select-String -Pattern "ReleaseNotes\s*= '(.*)'").Matches.Groups[1].Value
+        }
+
+        Write-Output $moduleInfo
+    }
+}

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -133,7 +133,7 @@ function Get-JVAggregatedData {
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
         [Alias('sort.metadata.nfo.translate.keeporiginaldescription')]
-        [String]$KeepOriginalDescription,
+        [Boolean]$KeepOriginalDescription,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
         [Alias('sort.format.delimiter')]

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -643,7 +643,7 @@ function Get-JVAggregatedData {
         # The displayname value is updated after the previous fields have already been scraped and translated
         $aggregatedDataObject.DisplayName = Convert-JVString -Data $aggregatedDataObject -FormatString $DisplayNameFormat -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress
 
-        if ($null -ne $Tag[0]) {
+        if ($Tag[0]) {
             $aggregatedDataObject.Tag = @()
             foreach ($entry in $Tag) {
                 $tagString = (Convert-JVString -Data $aggregatedDataObject -FormatString $entry -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress)
@@ -663,7 +663,7 @@ function Get-JVAggregatedData {
             }
         }
 
-        if ($null -ne $Credits[0]) {
+        if ($Credits[0]) {
             $aggregatedDataObject.Credits = @()
             foreach ($entry in $Credits) {
                 $credit = (Convert-JVString -Data $aggregatedDataObject -FormatString $entry -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress)

--- a/src/Javinizer/Public/Get-JVItem.ps1
+++ b/src/Javinizer/Public/Get-JVItem.ps1
@@ -57,20 +57,21 @@ function Get-JVItem {
             $RegexPtMatch = $Settings.'match.regex.ptmatch'
         }
 
-        $extensions = @()
         $ExcludedStrings = $ExcludedStrings -join '|'
 
         if ($Depth) {
             $files = Get-ChildItem -LiteralPath $Path -Recurse:$Recurse -Depth:$Depth | Where-Object {
                 $_.Extension -in $IncludedExtensions `
                     -and $_.Length -ge ($MinimumFileSize * 1MB) `
-                    -and $_.Name -notmatch $ExcludedStrings
+                    -and $_.Name -notmatch $ExcludedStrings `
+                    -and $_.Mode -notlike '*d*'
             }
         } else {
             $files = Get-ChildItem -LiteralPath $Path -Recurse:$Recurse | Where-Object {
                 $_.Extension -in $IncludedExtensions `
                     -and $_.Length -ge ($MinimumFileSize * 1MB) `
-                    -and $_.Name -notmatch $ExcludedStrings
+                    -and $_.Name -notmatch $ExcludedStrings `
+                    -and $_.Mode -notlike '*d*'
             }
         }
 

--- a/src/Javinizer/Public/Get-JVSettings.ps1
+++ b/src/Javinizer/Public/Get-JVSettings.ps1
@@ -1,0 +1,24 @@
+function Get-JVSettings {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [System.IO.FileInfo]$Path
+    )
+
+    process {
+        if ($PSBoundParameters.ContainsKey('Path')) {
+            $settingsPath = $Path
+        } else {
+            $settingsPath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvSettings.json'
+        }
+
+        try {
+            $rawSettings = Get-Content -Path $settingsPath -Raw
+            $settings = $rawSettings | ConvertFrom-Json -Depth 32
+        } catch {
+            Write-Error "Error occurred when retrieving settings: $PSItem" -ErrorAction Stop
+        }
+
+        Write-Output $settings
+    }
+}

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -444,7 +444,10 @@ function Javinizer {
         [Switch]$UpdateModule,
 
         [Parameter(ParameterSetName = 'Preview')]
-        [Switch]$Preview
+        [Switch]$Preview,
+
+        [Parameter(ParameterSetName = 'Passthru')]
+        [Switch]$OutSettings
     )
 
     process {
@@ -626,6 +629,12 @@ function Javinizer {
                     Get-JVItem -Settings $Settings -Path $Path -Recurse:$Recurse -Depth:$Depth -Strict:$Strict
                 } else {
                     Get-JVItem -Settings $Settings -Path $Path -Recurse:$Recurse -Strict:$Strict
+                }
+            }
+
+            'Passthru' {
+                if ($OutSettings) {
+                    Get-JVSettings
                 }
             }
 

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -171,7 +171,7 @@ function Set-JVMovie {
             $GroupActress = $Settings.'sort.format.groupactress'
         }
 
-        if ($RenameFile) {
+        if ($RenameFile -and (!($Update))) {
             $fileName = Convert-JVString -Data $Data -Format $FileFormat -PartNumber $PartNumber -MaxTitleLength $MaxTitleLength -Delimiter $DelimiterFormat -ActressLanguageJa:$ActressLanguageJa -FirstNameOrder:$FirstNameOrder -GroupActress:$GroupActress -IsFileName:$true
         } else {
             $fileName = (Get-Item -LiteralPath $Path).BaseName

--- a/src/Javinizer/Public/Update-JVModule.ps1
+++ b/src/Javinizer/Public/Update-JVModule.ps1
@@ -1,0 +1,127 @@
+function Update-JVModule {
+    [CmdletBinding()]
+    param (
+        [Parameter(ParameterSetName = 'Check')]
+        [Switch]$CheckUpdates,
+
+        [Parameter(ParameterSetName = 'Update')]
+        [Switch]$Update
+    )
+
+    begin {
+
+    }
+
+    process {
+        switch ($PsCmdlet.ParameterSetName) {
+            'Check' {
+                if (!($global:jvUpdateCheck)) {
+                    # Set global variable to determine that check has already been completed in the current session
+                    $global:jvUpdateCheck = $true
+                    $installedVersion = (Get-JVModuleInfo).Version
+                    $latestVersion = (Find-Module -Name 'Javinizer').Version
+                    Write-Debug "Installed version: $installedVersion"
+                    Write-Debug "Latest version: $latestVersion"
+
+                    if ($installedVersion -ne $latestVersion) {
+                        Write-Warning "There is a newer version of Javinizer available! (Set 'admin.updates.check' to false to hide this message)"
+                        Write-Warning "$installedVersion => $latestVersion"
+                    }
+                }
+            }
+
+            'Update' {
+                try {
+                    Get-InstalledModule -Name 'Javinizer'
+                } catch {
+                    Write-Error "You can only use this method to update if you installed Javinizer using 'Install-Module'" -ErrorAction Stop
+                }
+
+                $installedVersion = (Get-JVModuleInfo).Version
+                $latestVersion = (Find-Module -Name 'Javinizer').Version
+
+                if ($installedVersion -ne $latestVersion) {
+                    Write-Warning "Starting update process, please make sure to close all related Javinizer settings files before continuing"
+                    Write-Warning "Updating from version [$installedVersion => $latestVersion]"
+                    Pause
+
+                    try {
+                        $origSettings = Get-JVSettings
+
+                        if (Test-Path -Path $origSettings.'location.thumbcsv') {
+                            $origThumbsPath = (Get-Item -Path $origSettings.'location.thumbcsv').FullName
+                        } else {
+                            $origThumbsPath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvThumbs.csv'
+                        }
+
+                        if (Test-Path -Path $origSettings.'location.genrecsv') {
+                            $origGenresPath = (Get-Item -Path $origSettings.'location.genrecsv').FullName
+                        } else {
+                            $origGenresPath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvGenres.csv'
+                        }
+
+                        if (Test-Path -Path $origSettings.'location.uncensorcsv') {
+                            $origUncensorPath = (Get-Item -Path $origSettings.'location.uncensorcsv').FullName
+                        } else {
+                            $origUncensorPath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvUncensor.csv'
+                        }
+
+                        if (Test-Path -Path $origSettings.'location.historycsv') {
+                            $origHistoryPath = (Get-Item -Path $origSettings.'location.historycsv').FullName
+                        } else {
+                            $origHistoryPath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvHistory'
+                        }
+
+                        # Write all settings configurations to memory
+                        $origThumbs = Import-Csv -Path $origThumbsPath -Encoding utf8
+                        $origGenres = Import-Csv -Path $origGenresPath -Encoding utf8
+                        $origUncensor = Import-Csv -Path $origUncensorPath -Encoding utf8
+                        $origHistory = Import-Csv -Path $origHistoryPath -Encoding utf8
+
+                    } catch {
+                        Write-Error "Error occurred when retrieving existing settings: $PSItem" -ErrorAction Stop
+                    }
+
+                    try {
+                        Update-Module -Name 'Javinizer' -Force -Confirm:$false
+                    } catch {
+                        Write-Error "Error occurred when updating the Javinizer module: $PSItem" -ErrorAction Stop
+                    }
+
+                    $newModulePath = (Get-InstalledModule -Name 'Javinizer').InstalledLocation
+
+                    # Update jvSettings
+                    $newSettingsPath = Join-Path -Path $newModulePath -ChildPath 'jvSettings.json'
+                    $newSettings = Get-JVSettings -Path $newSettingsPath
+                    $origSettings.PSObject.Properties | ForEach-Object {
+                        $newSettings."$($_.Name)" = $_.Value
+                    }
+
+                    $newSettings | ConvertTo-Json -Depth 32 | Out-File -FilePath $newSettingsPath -Force -ErrorAction Continue
+
+                    # Update jvThumbs
+                    $newThumbsPath = Join-Path -Path $newModulePath -ChildPath 'jvThumbs.csv'
+                    $newThumbs = Import-Csv -Path $newThumbsPath -Encoding utf8
+                    $thumbsDifference = (Compare-Object -ReferenceObject $origThumbs -DifferenceObject $newThumbs).InputObject
+                    $thumbsDifference | Export-Csv -Path $newThumbsPath -Append -Encoding utf8 -ErrorAction Continue
+
+                    # Update jvGenres
+                    $newGenresPath = Join-Path -Path $newModulePath -ChildPath 'jvGenres.csv'
+                    $newGenres = Import-Csv -Path $newGenresPath -Encoding utf8
+                    $genresDifference = (Compare-Object -ReferenceObject $origGenres -DifferenceObject $newGenres).InputObject
+                    $genresDifference | Export-Csv -Path $newGenresPath -Append -Encoding utf8 -ErrorAction Continue
+
+                    # Update jvUncensor
+
+                    # Update jvHistory
+                    $newHistoryPath = Join-Path -Path $newModulePath -ChildPath 'jvHistory.csv'
+                    $newHistory = Import-Csv -Path $newHistoryPath -Encoding utf8
+                    $historyDifference = (Compare-Object -ReferenceObject $origHistory -DifferenceObject $newHistory).InputObject
+                    $historyDifference | Export-Csv -Path $newHistoryPath -Append -Encoding utf8 -ErrorAction Continue
+                } else {
+                    Write-Warning "You already have the latest version of Javinizer! [$installedVersion]"
+                }
+            }
+        }
+    }
+}

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -131,5 +131,6 @@
     "web.sort.manualsearch.r18zh": false,
     "web.navigation.pagesize": 5,
     "admin.log": true,
-    "admin.log.level": "info"
+    "admin.log.level": "info",
+    "admin.updates.check": true
 }

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -68,7 +68,7 @@
     "sort.metadata.nfo.translate.module": "googletrans",
     "sort.metadata.nfo.translate.field": ["description"],
     "sort.metadata.nfo.translate.language": "en",
-    "sort.metadata.nfo.translate.keeporiginaldescription": true,
+    "sort.metadata.nfo.translate.keeporiginaldescription": false,
     "sort.metadata.nfo.displayname": "[<ID>] <TITLE>",
     "sort.metadata.nfo.firstnameorder": false,
     "sort.metadata.nfo.actresslanguageja": false,


### PR DESCRIPTION
### Added

-   Added `-Preview` parameter to display file matcher details
-   Added `-OutSettings` parameter to passthru Javinizer settings object to shell
-   Added `admin.updates.check` setting to check for module updates on first run
-   **Experimental** Added `-UpdateModule` parameter to perform Javinizer module update with settings persistence

### Fixed

-   `sort.metadata.nfo.translate.keeporiginaldescription` no longer fails to check true/false value
-   Using `-Update` will no longer recreate the nfo file with a filename title
-   Directories with a file extension appended to the path name will no longer be detected as a movie