### PR TITLE
2.4.4

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,71 +5,95 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.4]
+
+### Added
+
+-   Added \<FILENAME> as a format string which converts to the movie's basename
+
+### Changed
+
+-   Downloaded screenshot names now have a 2 digit padding for the incremented number
+
+### Fixed
+
+-   Fixed issue where sort would fail when downloading movie screenshots
+-   Fixed issue where filematcher would erroneously detect 5 digit movies with a single trailing '0' as a contentId during multipart matching (e.g. DMM-070807_1) (#227)
+
 ## [2.4.3]
 
 ### Fixed
-- Fixed issue where genres were not being replaced from the genre csv (#235)
-- Fixed issue where `-Update` was not being applied properly
+
+-   Fixed issue where genres were not being replaced from the genre csv (#235)
+-   Fixed issue where `-Update` was not being applied properly
 
 ## [2.4.2]
 
 ### Fixed
-- GUI: Fixed custom appbar not being displayed
+
+-   GUI: Fixed custom appbar not being displayed
 
 ## [2.4.0]
 
 ### Added
-- Added `-OpenModule` parameter to open the Javinizer module directory
-- Added setting `scraper.option.addmaleactors` to scrape avdanyuwiki.com for male actors (#147)
-    -  Updated English names in the thumb csv will be added in a later release
-- Sorting files via the CLI now populates the history csv file (-OpenHistory)
-- GUI: Added ouput and filematcher preview
-- GUI: Added recurse depth selection on sort card
-- GUI: Added genre/tag editor popups
-- GUI: Added stats page that corresponds with the history csv
-- GUI: Added an advanced manual search workflow
-- GUI: Added tooltip descriptions for most GUI actions and settings options
-- GUI: Added better dark/light theme management, refreshed appbar
-- GUI: Added 'not matched' count to sort progress popup
+
+-   Added `-OpenModule` parameter to open the Javinizer module directory
+-   Added setting `scraper.option.addmaleactors` to scrape avdanyuwiki.com for male actors (#147)
+    -   Updated English names in the thumb csv will be added in a later release
+-   Sorting files via the CLI now populates the history csv file (-OpenHistory)
+-   GUI: Added ouput and filematcher preview
+-   GUI: Added recurse depth selection on sort card
+-   GUI: Added genre/tag editor popups
+-   GUI: Added stats page that corresponds with the history csv
+-   GUI: Added an advanced manual search workflow
+-   GUI: Added tooltip descriptions for most GUI actions and settings options
+-   GUI: Added better dark/light theme management, refreshed appbar
+-   GUI: Added 'not matched' count to sort progress popup
 
 ### Changed
-- **Updated settings metadata priority defaults to favor javlibrary over r18**
-- mgstageja scraper no longer includes actress aliases in the JapaneseName
-- jav321 scrapers no longer include actress aliases in the JapaneseName
-- History csv now includes all metadata fields
-- GUI: Installing the GUI no longer requires first-run setup via `-OpenGUI` and Docker
-- GUI: PowerShell Universal version upgraded from 1.4.7 => 1.5.13
-- GUI: Default port changed from 5000 => 8600
-- GUI: GUI now runs in a non-admin scope to allow easier access to network drives
+
+-   **Updated settings metadata priority defaults to favor javlibrary over r18**
+-   mgstageja scraper no longer includes actress aliases in the JapaneseName
+-   jav321 scrapers no longer include actress aliases in the JapaneseName
+-   History csv now includes all metadata fields
+-   GUI: Installing the GUI no longer requires first-run setup via `-OpenGUI` and Docker
+-   GUI: PowerShell Universal version upgraded from 1.4.7 => 1.5.13
+-   GUI: Default port changed from 5000 => 8600
+-   GUI: GUI now runs in a non-admin scope to allow easier access to network drives
 
 ### Fixed
-- Fixed issue where actress images would fail to download if they contained special characters on mgstage (#223)
-- Fixed issue causing update check to never run
-- Fixed issue with javlibraryja and javlibraryzh scrapers not accepting manual cloudflare cookies
-- Fixed issue where R18 series metadata included a blank 'tab' character
+
+-   Fixed issue where actress images would fail to download if they contained special characters on mgstage (#223)
+-   Fixed issue causing update check to never run
+-   Fixed issue with javlibraryja and javlibraryzh scrapers not accepting manual cloudflare cookies
+-   Fixed issue where R18 series metadata included a blank 'tab' character
 
 ## [2.3.3]
 
 ### Changed
-- `admin.updates.check` now checks on a 24 hour interval instead of on every run
-- Removed local dependencies on `-UpdateModule` - now runs properly
+
+-   `admin.updates.check` now checks on a 24 hour interval instead of on every run
+-   Removed local dependencies on `-UpdateModule` - now runs properly
 
 ### Fixed
-- Fixed JAVLibrary scraper not returning cover urls for certain movies
-- Fixed file matcher cleaning regex ".HD" => "\.HD"
+
+-   Fixed JAVLibrary scraper not returning cover urls for certain movies
+-   Fixed file matcher cleaning regex ".HD" => "\.HD"
 
 ## [2.3.2]
 
 ### Changed
-- Javdb scraper now accepts relative ID match rather than exact ID match to support matching mgstage titles
-    - mgstage `406FSDSS-169` <-> `FSDSS-169` javdb
+
+-   Javdb scraper now accepts relative ID match rather than exact ID match to support matching mgstage titles
+    -   mgstage `406FSDSS-169` <-> `FSDSS-169` javdb
 
 ### Fixed
-- Additional fixes for -UpdateModule
-- Filematcher now properly cleans ContentId (ID00123) to Id (ID-123) value
-- `-Strict` now properly works on updated Dmm url scraper
-- Added better debugging error when filematcher breaks on invalid multi-part format (#215)
-- Javlibrary ratings now properly return null when there is no rating value
+
+-   Additional fixes for -UpdateModule
+-   Filematcher now properly cleans ContentId (ID00123) to Id (ID-123) value
+-   `-Strict` now properly works on updated Dmm url scraper
+-   Added better debugging error when filematcher breaks on invalid multi-part format (#215)
+-   Javlibrary ratings now properly return null when there is no rating value
 
 ## [2.3.1]
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 -   Downloaded screenshot names now have a 2 digit padding for the incremented number
+-   `-UpdateModule` now copies tags, genre, history csv files to new module folder instead of doing a comparative replacement
 
 ### Fixed
 

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.4.3'
+    ModuleVersion     = '2.4.4'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Convert-JVString.ps1
+++ b/src/Javinizer/Private/Convert-JVString.ps1
@@ -152,7 +152,8 @@ function Convert-JVString {
             -replace '<ACTORS>', "$actresses" `
             -replace '<ORIGINALTITLE>', "$($Data.AlternateTitle)" `
             -replace '<RESOLUTION>', "$($Data.MediaInfo.VideoHeight)" `
-            -replace '<DIRECTOR>', "$($Data.Director)"
+            -replace '<DIRECTOR>', "$($Data.Director)" `
+            -replace '<FILENAME>', "$($Data.OriginalFileName)"
 
         foreach ($symbol in $invalidSymbols) {
             if ([regex]::Escape($symbol) -eq '/') {

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -209,7 +209,14 @@ function Convert-JVTitle {
             # Match ID-### - cd1, ID-### - cd2, etc.
             elseif ($fileBaseNameUpper[$x] -match "[-][0-9]{1,6}Z?E?R?\s?[-]\s?(cd|part|pt)?[-]?\d{1,3}") {
                 $fileP1, $fileP2, $fileP3 = $fileBaseNameUpper[$x] -split "([-][0-9]{1,6}Z?E?\s?[-])"
-                $fileBaseNameUpperCleaned += $fileP1 + "-" + (($fileP2 -replace '-', '') -replace '^0{1,5}', '').Trim().PadLeft(3, '0')
+
+                if ($fileBaseNameUpper[$x] -match '^0{2,5}') {
+                    # If match contentid format: DMM00234-1
+                    $fileBaseNameUpperCleaned += $fileP1 + "-" + (($fileP2 -replace '-', '') -replace '^0{1,5}', '').Trim().PadLeft(3, '0')
+                } else {
+                    # If match dvdid format: DMM-070807-1
+                    $fileBaseNameUpperCleaned += $fileP1 + "-" + (($fileP2 -replace '-', '')).Trim()
+                }
                 $filePartNum = ((($fileP3.Trim() -replace '-', '') -replace '^0{1,5}', '') -replace '(cd|part|pt)', '')
                 if ($filePartNum -match '^\d+$') {
                     $filePartNumber = [int]$filePartNum

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -192,7 +192,10 @@ function Get-JVAggregatedData {
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
         [Alias('location.tagcsv')]
-        [System.IO.FileInfo]$TagCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvTags.csv')
+        [System.IO.FileInfo]$TagCsvPath = (Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'jvTags.csv'),
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
+        [String]$FileName
     )
 
     process {
@@ -251,28 +254,29 @@ function Get-JVAggregatedData {
         }
 
         $aggregatedDataObject = [PSCustomObject]@{
-            Id             = $null
-            ContentId      = $null
-            DisplayName    = $null
-            Title          = $null
-            AlternateTitle = $null
-            Description    = $null
-            Rating         = $null
-            ReleaseDate    = $null
-            Runtime        = $null
-            Director       = $null
-            Maker          = $null
-            Label          = $null
-            Series         = $null
-            Tag            = $null
-            Tagline        = $null
-            Credits        = $null
-            Actress        = $null
-            Genre          = $null
-            CoverUrl       = $null
-            ScreenshotUrl  = $null
-            TrailerUrl     = $null
-            MediaInfo      = $MediaInfo
+            Id               = $null
+            ContentId        = $null
+            DisplayName      = $null
+            Title            = $null
+            AlternateTitle   = $null
+            Description      = $null
+            Rating           = $null
+            ReleaseDate      = $null
+            Runtime          = $null
+            Director         = $null
+            Maker            = $null
+            Label            = $null
+            Series           = $null
+            Tag              = $null
+            Tagline          = $null
+            Credits          = $null
+            Actress          = $null
+            Genre            = $null
+            CoverUrl         = $null
+            ScreenshotUrl    = $null
+            TrailerUrl       = $null
+            OriginalFileName = $FileName
+            MediaInfo        = $MediaInfo
         }
 
         $selectedDataObject = [PSCustomObject]@{

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -998,7 +998,7 @@ function Javinizer {
 
                     $javData = Get-JVData -Url $Url -Settings $Settings -UncensorCsvPath $uncensorCsvPath -Session:$CfSession -JavdbSession:$Settings.'javdb.cookie.session'
                     if ($null -ne $javData) {
-                        $javAggregatedData = $javData | Get-JVAggregatedData -Settings $Settings -MediaInfo $mediaInfo | Test-JVData -RequiredFields $Settings.'sort.metadata.requiredfield'
+                        $javAggregatedData = $javData | Get-JVAggregatedData -Settings $Settings -FileName $javMovies.BaseName -MediaInfo $mediaInfo | Test-JVData -RequiredFields $Settings.'sort.metadata.requiredfield'
                         if ($javAggregatedData.NullFields -eq '') {
                             $sortDataParameters = @{
                                 Data            = $javAggregatedData.Data
@@ -1077,7 +1077,7 @@ function Javinizer {
                             }
 
                             $javData = Get-JVData -Id $movie.Id -Settings $Settings -UncensorCsvPath $uncensorCsvPath -Strict:$Strict -Session:$CfSession -JavdbSession:$Settings.'javdb.cookie.session'
-                            $javAggregatedData = $javData | Get-JVAggregatedData -Settings $Settings -MediaInfo $mediaInfo | Test-JVData -RequiredFields $Settings.'sort.metadata.requiredfield'
+                            $javAggregatedData = $javData | Get-JVAggregatedData -Settings $Settings -FileName $movie.BaseName -MediaInfo $mediaInfo | Test-JVData -RequiredFields $Settings.'sort.metadata.requiredfield'
                             $sortDataParameters = @{
                                 Data            = $javAggregatedData.Data
                                 Path            = $movie.FullName

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -219,9 +219,9 @@ function Set-JVMovie {
                         try {
                             $cropScriptPath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'crop.py'
                             if (Test-Path -LiteralPath $cropScriptPath) {
-                                foreach ($poster in $sortData.PosterName) {
+                                foreach ($poster in $sortData.PosterPath) {
                                     $pythonThumbPath = $sortData.ThumbPath -replace '\\', '/'
-                                    $pythonPosterPath = $sortData.PosterPath -replace '\\', '/'
+                                    $pythonPosterPath = $poster -replace '\\', '/'
                                     if ($sortData.PartNumber -eq 0 -or $sortData.PartNumber -eq 1) {
                                         if ($Force) {
                                             if (Test-Path -LiteralPath $sortData.PosterPath) {
@@ -229,30 +229,30 @@ function Set-JVMovie {
                                             }
                                             if ([System.Environment]::OSVersion.Platform -eq 'Win32NT') {
                                                 python $cropScriptPath $pythonThumbPath $pythonPosterPath
-                                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $($sortData.ThumbPath)] cropped to path [$($sortData.PosterPath)]"
+                                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $($sortData.ThumbPath)] cropped to path [$($poster)]"
                                             } elseif ([System.Environment]::OSVersion.Platform -eq 'Unix') {
                                                 python3 $cropScriptPath $pythonThumbPath $pythonPosterPath
-                                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $($sortData.ThumbPath)] cropped to path [$($sortData.PosterPath)]"
+                                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $($sortData.ThumbPath)] cropped to path [$($poster)]"
                                             }
-                                        } elseif (!(Test-Path -LiteralPath $sortData.PosterPath)) {
+                                        } elseif (!(Test-Path -LiteralPath $poster)) {
                                             if ([System.Environment]::OSVersion.Platform -eq 'Win32NT') {
                                                 python $cropScriptPath $pythonThumbPath $pythonPosterPath
-                                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $($sortData.ThumbPath)] cropped to path [$($sortData.PosterPath)]"
+                                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $($sortData.ThumbPath)] cropped to path [$($poster)]"
                                             } elseif ([System.Environment]::OSVersion.Platform -eq 'Unix') {
                                                 python3 $cropScriptPath $pythonThumbPath $pythonPosterPath
-                                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $($sortData.ThumbPath)] cropped to path [$($sortData.PosterPath)]"
+                                                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $($sortData.ThumbPath)] cropped to path [$($poster)]"
                                             }
                                         }
                                     } else {
-                                        if (!(Test-Path -LiteralPath $sortData.PosterPath)) {
+                                        if (!(Test-Path -LiteralPath $poster)) {
                                             Start-Sleep -Seconds 2
-                                            if (!(Test-Path -LiteralPath $sortData.PosterPath)) {
+                                            if (!(Test-Path -LiteralPath $poster)) {
                                                 if ([System.Environment]::OSVersion.Platform -eq 'Win32NT') {
                                                     python $cropScriptPath $pythonThumbPath $pythonPosterPath
-                                                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $sortData.ThumbPath] cropped to path [$sortData.PosterPath]"
+                                                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $sortData.ThumbPath] cropped to path [$poster]"
                                                 } elseif ([System.Environment]::OSVersion.Platform -eq 'Unix') {
                                                     python3 $cropScriptPath $pythonThumbPath $pythonPosterPath
-                                                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $sortData.ThumbPath] cropped to path [$sortData.PosterPath]"
+                                                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] [Poster - $sortData.ThumbPath] cropped to path [$poster]"
                                                 }
                                             }
                                         }
@@ -263,7 +263,7 @@ function Set-JVMovie {
                                 Write-JLog -Level Error -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Crop.py file is missing or cannot be found at path [$cropScriptPath]"
                             }
                         } catch {
-                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Error occurred when creating poster image file [$($sortData.PosterPath)]: $PSItem"
+                            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Error occurred when creating poster image file [$($poster)]: $PSItem"
                         }
                     }
                 }
@@ -321,9 +321,11 @@ function Set-JVMovie {
                         }
 
                         foreach ($screenshot in $Data.ScreenshotUrl) {
+                            $paddedIndex = $index.ToString().PadLeft(2, '0')
+                            $screenshotName = "$($sortData.ScreenshotImgName)$paddedIndex.jpg"
                             $webClient = New-Object System.Net.WebClient
                             $webclient.Headers.Add("User-Agent: Other")
-                            $screenshotPath = Join-Path -Path $sortData.ScreenshotFolderPath -ChildPath "$sortData.ScreenshotImgName$index.jpg"
+                            $screenshotPath = Join-Path -Path $sortData.ScreenshotFolderPath -ChildPath $screenshotName
                             if ($sortData.PartNumber -eq 0 -or $sortData.PartNumber -eq 1) {
                                 if ($Force.IsPresent) {
                                     if (Test-Path -LiteralPath $screenshotPath) {
@@ -347,7 +349,7 @@ function Set-JVMovie {
                             }
                         }
                     } catch {
-                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Error occurred when creating screenshot image files: $PSItem"
+                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($Data.Id)] [$($MyInvocation.MyCommand.Name)] Error occurred when creating screenshot image file [$screenshot] from to [$screenshotPath]: $PSItem"
                     }
                 }
             }

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -3669,6 +3669,7 @@ $Pages += New-UDPage -Name "Settings" -Content {
                         <LABEL>
                         <ACTORS>
                         <ORIGINALTITLE>
+                        <FILENAME
                         <RESOLUTION>'
                         New-UDGrid -Item -ExtraSmallSize 12 -SmallSize 12 -Content {
                             New-UDGrid -Container -Content {

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -1,4 +1,4 @@
-﻿$cache:guiVersion = '2.4.3-1'
+﻿$cache:guiVersion = '2.4.4-1'
 
 # Define Javinizer module file paths
 $cache:modulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -62,7 +62,7 @@
   "sort.format.file": "<ID>",
   "sort.format.folder": "<ID> [<STUDIO>] - <TITLE> (<YEAR>)",
   "sort.format.outputfolder": "",
-  "sort.format.posterimg": "folder",
+  "sort.format.posterimg": ["folder"],
   "sort.format.thumbimg": "fanart",
   "sort.format.trailervid": "<ID>-trailer",
   "sort.format.nfo": "<ID>",


### PR DESCRIPTION
### Added

-   Added \<FILENAME> as a format string which converts to the movie's basename

### Changed

-   Downloaded screenshot names now have a 2 digit padding for the incremented number
- -   `-UpdateModule` now copies tags, genre, history csv files to new module folder instead of doing a comparative replacement

### Fixed

-   Fixed issue where sort would fail when downloading movie screenshots (#239)
-   Fixed issue where filematcher would erroneously detect 5 digit movies with a single trailing '0' as a contentId during multipart matching (e.g. DMM-070807_1) (#227)