### PR TITLE
2.4.7

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.7]
+
+### Fixed
+- Using `<TITLE>` at the end of a directory format string no longer errors when creating metadata files (#245)
+- JavBus genre metadata scraper updated for site changes
+
 ## [2.4.6]
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN pwsh -c "Set-PSRepository 'PSGallery' -InstallationPolicy Trusted" \
     && pwsh -c "Install-Module UniversalDashboard.UDSpinner" \
     && pwsh -c "Install-Module UniversalDashboard.UDScrollUp" \
     && pwsh -c "Install-Module UniversalDashboard.CodeEditor" \
-    && pwsh -c "Install-Module Javinizer -AllowPrerelease"
+    && pwsh -c "Install-Module Javinizer"
 
 # Install python modules
 RUN pip3 install pillow \

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -150,7 +150,7 @@
             ReleaseNotes             = 'https://github.com/jvlflame/Javinizer/blob/master/.github/CHANGELOG.md'
 
             # Prerelease string of this module
-            Prerelease               = 'alpha'
+            # Prerelease               = 'alpha'
 
             # Flag to indicate whether the module requires explicit user acceptance for install/update/save
             RequireLicenseAcceptance = $false

--- a/src/Javinizer/Private/Scraper.Javbus.ps1
+++ b/src/Javinizer/Private/Scraper.Javbus.ps1
@@ -193,7 +193,7 @@ function Get-JavbusGenre {
         $genre = @()
         try {
             $genre = ($Webrequest | ForEach-Object { $_ -split '\n' } |
-                Select-String '<span class="genre"><a href="(.*)\/genre\/(.*)">(.*)<\/a><\/span>').Matches |
+                Select-String '<a href="(.*)\/genre\/(.*)">(.*)<\/a><\/label><\/span>').Matches |
             ForEach-Object { $_.Groups[3].Value }
         } catch {
             return

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -1,4 +1,4 @@
-﻿$cache:guiVersion = '2.4.6-1'
+﻿$cache:guiVersion = '2.4.7-1'
 
 # Define Javinizer module file paths
 $cache:modulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation


### PR DESCRIPTION
## [2.4.7]

### Fixed
- Using `<TITLE>` at the end of a directory format string no longer errors when creating metadata files (#245)
- JavBus genre metadata scraper updated for site changes