### PR TITLE
2.4.8

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.8]
+
+### Added
+- Added `EnglishAlias` and `JapaneseAlias` properties to JAVLibrary scraper output
+- Setting `sort.metadata.nfo.preferactressalias` added to replace the default actress with the oldest alias in the aggregated metadata
+    - This can be used to "normalize" your actresses if you use JAVLibrary as your primary actress metadata
+### Fixed
+- Various fixes to regex matcher which were altering results
+- Mgstage scraper fixed for site HTML changes
+- Tag/Genres no longer being automatically replaced on a null replacement value
+
+
 ## [2.4.7]
 
 ### Fixed

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.4.7'
+    ModuleVersion     = '2.4.8'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -85,15 +85,15 @@ function Convert-JVTitle {
                     $partNum = ($file | Select-String $RegexString).Matches.Groups[$RegexPtMatch].Value
 
                     # If ID#### and there's no hypen, subsequent searches will fail
-                    if ($id -match '^([a-z]+)(\d+)$') {
+                    <# if ($id -match '^([a-z]+)(\d+)$') {
                         $id = $Matches[1] + "-" + ($Matches[2] -replace '^0{1,5}', '').PadLeft(3, '0')
-                    }
+                    } #>
                 } catch {
                     Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "File [$file] not matched by regex"
                     break
                 }
                 if ($fileBaseNameUpper -eq 1) {
-                    if ($partNum -ne '') {
+                    if ($partNum -ne '' -and $null -ne $partNum) {
                         $fileBaseNameUpper = "$id-PT$PartNum"
                     } elseif ($id -ne '') {
                         $fileBaseNameUpper = "$id"
@@ -101,7 +101,7 @@ function Convert-JVTitle {
                         $fileBaseNameUpper = $file
                     }
                 } else {
-                    if ($partNum -ne '') {
+                    if ($partNum -ne '' -and $null -ne $partNum) {
                         $fileBaseNameUpper[$index] = "$id-PT$PartNum"
                     } elseif ($id -ne '') {
                         $fileBaseNameUpper[$index] = "$id"
@@ -275,7 +275,7 @@ function Convert-JVTitle {
 
             # Turn on strict filematching if the movie does not appear to be a standard DVD Id format
             # This will require less reliance on using -Strict during commandline usage
-            if ($movieId -notmatch '([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)') {
+            if ($movieId -notmatch '([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)' -and $RegexEnabled -eq $false) {
                 $Strict = $true
             }
 

--- a/src/Javinizer/Private/Scraper.Mgstage.ps1
+++ b/src/Javinizer/Private/Scraper.Mgstage.ps1
@@ -198,7 +198,7 @@ function Get-MgstageGenre {
 
     process {
         $genreArray = @()
-        $genreHtml = ((($Webrequest.Content -split '<th>ジャンル：<\/th>')[1] -split '<\/td>')[0]) -split '<a href="\/search\/search\.php\?image_word_ids\[\]=.*">' | ForEach-Object { ($_ -replace '<td>' -replace '<\/a>').Trim() } | Where-Object { $_ -ne '' }
+        $genreHtml = ((($Webrequest.Content -split '<th>ジャンル：<\/th>')[1] -split '<\/td>')[0]) -split '<a href="\/search\/csearch\.php\?genre\[\]=.*">' | ForEach-Object { ($_ -replace '<td>' -replace '<\/a>').Trim() } | Where-Object { $_ -ne '' }
 
         foreach ($genre in $genreHtml) {
             $genre = Convert-HtmlCharacter -String $genre
@@ -221,7 +221,7 @@ function Get-MgstageActress {
 
     process {
         $movieActressObject = @()
-        $movieActress = (((($Webrequest.Content -split '<th>出演：<\/th>')[1] -split '<\/td>')[0]) -replace '<td>' -replace '<\/a>' -replace '<a href="\/search\/search\.php\?image_word_ids\[\]=.*">') -split '\n' `
+        $movieActress = (((($Webrequest.Content -split '<th>出演：<\/th>')[1] -split '<\/td>')[0]) -replace '<td>' -replace '<\/a>' -replace '<a href="\/search\/csearch\.php\?actor\[\]=.*">') -split '\n' `
         | ForEach-Object { ($_).Trim() } | Where-Object { $_ -ne '' }
 
         foreach ($actress in $movieActress) {

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -636,6 +636,8 @@ function Get-JVAggregatedData {
                         if ($replaceGenres.Replacement[$genreIndexNum] -ne '' -and $null -ne $replaceGenres.Replacement[$genreIndexNum]) {
                             $newGenres += $replaceGenres.Replacement[$genreIndexNum]
                             Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($aggregatedDataObject.Id)] [$($MyInvocation.MyCommand.Name)] [Genre - $($replaceGenres.Original[$genreIndexNum])] replaced as [$($replaceGenres.Replacement[$genreIndexNum])]"
+                        } else {
+                            $newGenres += $genre
                         }
                     } else {
                         $newGenres += $genre
@@ -822,6 +824,8 @@ function Get-JVAggregatedData {
                         if ($replaceTags.Replacement[$tagIndexNum] -ne '' -and $null -ne $replaceTags.Replacement[$tagIndexNum]) {
                             $newTags += $replaceTags.Replacement[$tagIndexNum]
                             Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($aggregatedDataObject.Id)] [$($MyInvocation.MyCommand.Name)] [Tag - $($replaceTags.Original[$tagIndexNum])] replaced as [$($replaceTags.Replacement[$tagIndexNum])]"
+                        } else {
+                            $newtags += $tag
                         }
                     } else {
                         $newTags += $tag

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -353,7 +353,7 @@ function Get-JVAggregatedData {
                     } else {
                         $aggregatedDataObject.$field = $sourceData.$field
                     }
-                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [$field - $priority] Set to [$($sourceData.$field | ConvertTo-Json -Compress)]"
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [$field - $priority] Set to [$($sourceData.$field | ConvertTo-Json -Depth 32 -Compress)]"
                 }
             }
         }
@@ -476,14 +476,14 @@ function Get-JVAggregatedData {
                                 $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched.Index].LastName
                                 $aggregatedDataObject.Actress[$x].JapaneseName = $actressCsv[$matched.Index].JapaneseName
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $actressCsv[$matched.Index].ThumbUrl
-                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Alias - $aliasString] converted to [$actressString] using FirstName match"
                             } elseif ($matched.Count -gt 1) {
                                 $aggregatedDataObject.Actress[$x].FirstName = $actressCsv[$matched[0].Index].FirstName
                                 $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched[0].Index].LastName
                                 $aggregatedDataObject.Actress[$x].JapaneseName = $actressCsv[$matched[0].Index].JapaneseName
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $actressCsv[$matched[0].Index].ThumbUrl
-                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Alias - $aliasString] converted to [$actressString] using FirstName match"
                             }
                         } elseif ($matched = Compare-Object -ReferenceObject $aliasObject -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('FirstName', 'LastName')) {
@@ -493,14 +493,14 @@ function Get-JVAggregatedData {
                                 $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched.Index].LastName
                                 $aggregatedDataObject.Actress[$x].JapaneseName = $actressCsv[$matched.Index].JapaneseName
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $actressCsv[$matched.Index].ThumbUrl
-                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Alias - $aliasString] converted to [$actressString] using FirstName LastName match"
                             } elseif ($matched.Count -gt 1) {
                                 $aggregatedDataObject.Actress[$x].FirstName = $actressCsv[$matched[0].Index].FirstName
                                 $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched[0].Index].LastName
                                 $aggregatedDataObject.Actress[$x].JapaneseName = $actressCsv[$matched[0].Index].JapaneseName
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $actressCsv[$matched[0].Index].ThumbUrl
-                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Alias - $aliasString] converted to [$actressString] using FirstName LastName match"
                             }
                         } elseif (($aggregatedDataObject.Actress[$x].JapaneseName -ne '') -and ($matched = Compare-Object -ReferenceObject $aliasObject -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('JapaneseName'))) {
@@ -510,7 +510,7 @@ function Get-JVAggregatedData {
                                 $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched.Index].LastName
                                 $aggregatedDataObject.Actress[$x].JapaneseName = $actressCsv[$matched.Index].JapaneseName
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $actressCsv[$matched.Index].ThumbUrl
-                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Alias - $aliasString] converted to [$actressString] using JapaneseName match"
                             } elseif ($matched.Count -gt 1) {
                                 $actressString = "$($actressCsv[$matched.Index].LastName) $($actressCsv[$matched.Index].FirstName) - $($actressCsv[$matched[0].Index].JapaneseName)".Trim()
@@ -518,7 +518,7 @@ function Get-JVAggregatedData {
                                 $aggregatedDataObject.Actress[$x].LastName = $actressCsv[$matched[0].Index].LastName
                                 $aggregatedDataObject.Actress[$x].JapaneseName = $actressCsv[$matched[0].Index].JapaneseName
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $actressCsv[$matched[0].Index].ThumbUrl
-                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Alias - $aliasString] converted to [$actressString] using JapaneseName match"
                             }
                         }
@@ -529,7 +529,7 @@ function Get-JVAggregatedData {
                     $matched = @()
                     $matchedActress = @()
                     if (($aggregatedDataObject.Actress[$x].JapaneseName -ne '') -and ($matched = Compare-Object -ReferenceObject $actressCsv -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('JapaneseName'))) {
-                        $originalActressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                        $originalActressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                         if ($matched.Count -eq 1) {
                             $matchedActress = $matched
                             $aggregatedDataObject.Actress[$x].FirstName = $matchedActress.FirstName
@@ -538,7 +538,7 @@ function Get-JVAggregatedData {
                             if ($null -eq $aggregatedDataObject.ThumbUrl -or $aggregatedDataObject.ThumbUrl -eq '') {
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $matchedActress.ThumbUrl
                             }
-                            $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                            $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                             Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Actress - $originalActressString] matched to [$actressString]"
                         } elseif ($matched.Count -gt 1) {
                             $matchedActress = $matched | Where-Object { $_.FirstName -like $aggregatedDataObject.Actress[$x].FirstName -and $_.LastName -like $aggregatedDataObject.Actress[$x].LastName }
@@ -549,12 +549,12 @@ function Get-JVAggregatedData {
                                 if ($null -eq $aggregatedDataObject.ThumbUrl -or $aggregatedDataObject.ThumbUrl -eq '') {
                                     $aggregatedDataObject.Actress[$x].ThumbUrl = $matchedActress.ThumbUrl
                                 }
-                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                                $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                                 Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Actress - $originalActressString] matched to [$actressString]"
                             }
                         }
                     } elseif (($aggregatedDataObject.Actress[$x].LastName -eq '' -and $aggregatedDataObject.Actress[$x].FirstName -ne '') -and ($matched = Compare-Object -ReferenceObject ($actressCsv | Where-Object { $_.LastName -eq '' }) -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('FirstName'))) {
-                        $originalActressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                        $originalActressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                         if ($matched.Count -eq 1) {
                             $matchedActress = $matched
                             $aggregatedDataObject.Actress[$x].FirstName = $matchedActress.FirstName
@@ -563,11 +563,11 @@ function Get-JVAggregatedData {
                             if ($null -eq $aggregatedDataObject.ThumbUrl -or $aggregatedDataObject.ThumbUrl -eq '') {
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $matchedActress.ThumbUrl
                             }
-                            $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                            $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                             Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Actress - $originalActressString] matched to [$actressString]"
                         }
                     } elseif ($matched = Compare-Object -ReferenceObject $actressCsv -DifferenceObject $aggregatedDataObject.Actress[$x] -IncludeEqual -ExcludeDifferent -PassThru -Property @('FirstName', 'LastName')) {
-                        $originalActressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                        $originalActressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                         if ($matched.Count -eq 1) {
                             $matchedActress = $matched
                             $aggregatedDataObject.Actress[$x].FirstName = $matchedActress.FirstName
@@ -576,7 +576,7 @@ function Get-JVAggregatedData {
                             if ($null -eq $aggregatedDataObject.ThumbUrl -or $aggregatedDataObject.ThumbUrl -eq '') {
                                 $aggregatedDataObject.Actress[$x].ThumbUrl = $matchedActress.ThumbUrl
                             }
-                            $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Compress
+                            $actressString = $aggregatedDataObject.Actress[$x] | ConvertTo-Json -Depth 32 -Compress
                             Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Debug -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] [Actress - $originalActressString] matched to [$actressString]"
                         }
                     }

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -919,7 +919,7 @@ function New-JVAppBar {
     )
 
     $drawer = New-UDDrawer -Children {
-        New-UDList -SubHeader "Javinzer Web GUI v$($cache:guiVersion)" -Children {
+        New-UDList -SubHeader "Javinizer Web GUI v$($cache:guiVersion)" -Children {
             New-UDListItem -Label 'Sort' -Icon $iconSearchLocation -OnClick {
                 Invoke-UDRedirect -Url '/sort'
             }

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -1,4 +1,4 @@
-﻿$cache:guiVersion = '2.4.7-1'
+﻿$cache:guiVersion = '2.4.8-1'
 
 # Define Javinizer module file paths
 $cache:modulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation
@@ -133,6 +133,7 @@ $sortSettings = @(
     'sort.metadata.nfo.actresslanguageja',
     'sort.metadata.nfo.unknownactress',
     'sort.metadata.nfo.actressastag',
+    'sort.metadata.nfo.preferactressalias',
     'sort.metadata.nfo.originalpath',
     'sort.metadata.thumbcsv',
     'sort.metadata.thumbcsv.autoadd',
@@ -3564,6 +3565,7 @@ $Pages += New-UDPage -Name "Settings" -Content {
                                 'sort.metadata.nfo.actresslanguageja' { 'Specifies to prefer Japanese names when creating the metadata nfo' }
                                 'sort.metadata.nfo.unknownactress' { 'Specifies to add an "Unknown" actress to sorted movies without any actresses' }
                                 'sort.metadata.nfo.actressastag' { 'Specifies to add actresses as tags in the nfo file' }
+                                'sort.metadata.nfo.preferactressalias' { 'Specifies to prefer the oldest actress alias to normalize your metadata' }
                                 'sort.metadata.nfo.originalpath' { 'Specifies to add an "originalpath" field to the nfo specifying the location the movie was last sorted from' }
                                 'sort.metadata.thumbcsv' { 'Specifies to use the thumbnail csv to replace actor names and thumbs when aggregating metadata' }
                                 'sort.metadata.thumbcsv.autoadd' { 'Specifies to automatically add missing actor to the thumbnail csv when scraping using the R18 or R18Zh scrapers' }

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -83,6 +83,7 @@
   "sort.metadata.nfo.unknownactress": true,
   "sort.metadata.nfo.originalpath": false,
   "sort.metadata.nfo.actressastag": false,
+  "sort.metadata.nfo.preferactressalias": false,
   "sort.metadata.nfo.format.tag": "<SET>",
   "sort.metadata.nfo.format.tagline": "",
   "sort.metadata.nfo.format.credits": [],


### PR DESCRIPTION
### Added
- Added `EnglishAlias` and `JapaneseAlias` properties to JAVLibrary scraper output
- Setting `sort.metadata.nfo.preferactressalias` added to replace the default actress with the oldest alias in the aggregated metadata
    - This can be used to "normalize" your actresses if you use JAVLibrary as your primary actress metadata
### Fixed
- Various fixes to regex matcher which were altering results
- Mgstage scraper fixed for site HTML changes
- Tag/Genres no longer being automatically replaced on a null replacement value