### PR TITLE
2.5.2

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.2]
+### Added
+- Add setting to toggle the addition of generic actress role of `<role>Actress</role>` (#273)
+  -   `sort.metadata.nfo.addgenericrole`
+### Fixed
+- 3 -> 0 retries on webrequest to check for javlibrary cloudflare blocking to speed up initialization
+- Fixed json conversion loop which was breaking multiple javinizer GUI components
+- Regex multi-part matcher for movies that don't match standard DVD ID format should now match properly
+- Duplicate actresses without Japanese name should now be ignored from actress autoadd to thumb csv (again)
+
 ## [2.5.1]
 
 ### Added

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.5.1'
+    ModuleVersion     = '2.5.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -95,7 +95,7 @@ function Convert-JVTitle {
                 }
                 if ($fileBaseNameUpper -eq 1) {
                     if ($partNum -ne '' -and $null -ne $partNum) {
-                        $fileBaseNameUpper = "$id-PT$PartNum"
+                        $fileBaseNameUpper = "$id-pt$PartNum"
                     } elseif ($id -ne '') {
                         $fileBaseNameUpper = "$id"
                     } else {
@@ -103,7 +103,7 @@ function Convert-JVTitle {
                     }
                 } else {
                     if ($partNum -ne '' -and $null -ne $partNum) {
-                        $fileBaseNameUpper[$index] = "$id-PT$PartNum"
+                        $fileBaseNameUpper[$index] = "$id-pt$PartNum"
                     } elseif ($id -ne '') {
                         $fileBaseNameUpper[$index] = "$id"
                     } else {
@@ -223,6 +223,19 @@ function Convert-JVTitle {
                 if ($filePartNum -match '^\d+$') {
                     $filePartNumber = [int]$filePartNum
                 }
+            }
+
+            elseif ($RegexEnabled) {
+                $fileP1, $fileP2 = $fileBaseNameUpper[$x] -split "-pt"
+
+                $filePartNum = ((($fileP2.Trim() -replace '-', '' -replace '\.', '') -replace '^0{1,5}', '') -replace '(cd|part|pt)', '')
+                if ($filePartNum -match '^\d+$') {
+                    $filePartNumber = [int]$filePartNum
+                    $fileBaseNameUpperCleaned += $fileP1
+                } else {
+                    $fileBaseNameUpperCleaned += $fileBaseNameUpper[$x]
+                }
+
             }
 
             # Match everything else

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -378,7 +378,7 @@ function Get-JVAggregatedData {
                     if ($Data.Source -contains 'r18') {
                         $r18Data = $Data | Where-Object { $_.Source -eq 'r18' }
                         foreach ($actress in $r18Data.Actress) {
-                            if ($actress.JapaneseName -ne '' -and ($actress.JapaneseName -notin $actressCsv.JapaneseName)) {
+                            if (($actress.JapaneseName -ne '' -and $null -ne $actress.JapaneseName) -and ($actress.JapaneseName -notin $actressCsv.JapaneseName)) {
                                 try {
                                     $fullName = "$($actress.LastName) $($actress.FirstName)".Trim()
                                     $actressObject = [PSCustomObject]@{

--- a/src/Javinizer/Public/Get-JVNfo.ps1
+++ b/src/Javinizer/Public/Get-JVNfo.ps1
@@ -86,7 +86,10 @@ function Get-JVNfo {
         [String]$OriginalPath,
 
         [Parameter()]
-        [Boolean]$AltNameRole
+        [Boolean]$AltNameRole,
+
+        [Parameter()]
+        [Boolean]$AddGenericRole
     )
 
     process {
@@ -228,13 +231,22 @@ function Get-JVNfo {
     </actor>
 
 "@
-            } else {
+            } elseif ($AddGenericRole) {
                 $actressNfoString = @"
     <actor>
         <name>$actressName</name>
         <altname>$altName</altname>
         <thumb>$($item.ThumbUrl)</thumb>
         <role>Actress</role>
+    </actor>
+
+"@
+            } else {
+                $actressNfoString = @"
+    <actor>
+        <name>$actressName</name>
+        <altname>$altName</altname>
+        <thumb>$($item.ThumbUrl)</thumb>
     </actor>
 
 "@

--- a/src/Javinizer/Public/Get-JVSortData.ps1
+++ b/src/Javinizer/Public/Get-JVSortData.ps1
@@ -184,7 +184,8 @@ function Get-JVSortData {
             ScreenshotImgName    = $screenshotImgName
             ScreenshotFolderName = $screenshotFolderName
             ActorFolderName      = $actorFolderName
-            ParentPath           = (Get-Item -LiteralPath $Path).Directory
+            RenameNewPath        = ((Get-Item -LiteralPath $Path).Directory.Parent).ToString()
+            ParentPath           = ((Get-Item -LiteralPath $Path).Directory).ToString()
             FilePath             = $filePath
             FolderPath           = $folderPath
             NfoPath              = $nfoPath

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -822,7 +822,7 @@ function Javinizer {
                 }
 
                 if ($Nfo) {
-                    $nfoData = $data.Data | Get-JVNfo -ActressLanguageJa:$Settings.'sort.metadata.nfo.actresslanguageja' -NameOrder:$Settings.'sort.metadata.nfo.firstnameorder' -AltNameRole:$Settings.'sort.metadata.nfo.altnamerole'
+                    $nfoData = $data.Data | Get-JVNfo -ActressLanguageJa:$Settings.'sort.metadata.nfo.actresslanguageja' -NameOrder:$Settings.'sort.metadata.nfo.firstnameorder' -AltNameRole:$Settings.'sort.metadata.nfo.altnamerole' -AddGenericRole:$Settings.'sort.metadata.nfo.addgenericrole'
                     Write-Output $nfoData
                 } elseif ($Search -and $Aggregated) {
                     [PSCustomObject]@{

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -660,20 +660,20 @@ function Javinizer {
                 $ProgressPreference = 'SilentlyContinue'
                 if (!($CfSession)) {
                     try {
-                        Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -Verbose:$false | Out-Null
+                        Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -MaximumRetryCount 0 -Verbose:$false | Out-Null
                     } catch {
                         try {
                             $CfSession = Get-CfSession -cf_chl_2:$Settings.'javlibrary.cookie.cf_chl_2' -cf_chl_prog:$Settings.'javlibrary.cookie.cf_chl_prog' -cf_clearance:$Settings.'javlibrary.cookie.cf_clearance' -UserAgent:$Settings.'javlibrary.browser.useragent' -BaseUrl $Settings.'javlibrary.baseurl'
                             # Testing with the newly created session sometimes fails if there is no wait time
                             Start-Sleep -Seconds 1
-                            Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -Verbose:$false | Out-Null
+                            Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -MaximumRetryCount 0 -Verbose:$false | Out-Null
                         } catch {
                             Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($MyInvocation.MyCommand.Name)] Unable reach Javlibrary, enter JAVLibrary cookies and browser useragent to use the scraper"
                             $CfSession = Get-CfSession -BaseUrl $Settings.'javlibrary.baseurl'
                             # Testing with the newly created session sometimes fails if there is no wait time
                             Start-Sleep -Seconds 1
                             try {
-                                Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -Verbose:$false | Out-Null
+                                Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -MaximumRetryCount 0 -Verbose:$false | Out-Null
                                 if ($CfSession) {
                                     $originalSettingsContent = Get-Content -Path $SettingsPath
                                     $cookies = $CfSession.Cookies.GetCookies($Settings.'javlibrary.baseurl')
@@ -697,7 +697,7 @@ function Javinizer {
                     }
                 } else {
                     try {
-                        Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -Verbose:$false | Out-Null
+                        Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -MaximumRetryCount 0 -Verbose:$false | Out-Null
                     } catch {
                         Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Unable reach Javlibrary, invalid websession values"
                     }

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -209,7 +209,7 @@ function Set-JVMovie {
                         Start-Sleep -Seconds 5
                     }
                     Rename-Item -LiteralPath $sortData.ParentPath -NewName $sortData.FolderName -ErrorAction SilentlyContinue
-                    $Path = Join-Path -Path $sortData.ParentPath.Parent -ChildPath $sortData.FolderName -AdditionalChildPath $Path.Name
+                    $Path = Join-Path -Path $sortData.RenameNewPath -ChildPath $sortData.FolderName -AdditionalChildPath $Path.Name
                 } else {
                     if (!(Test-Path -LiteralPath $sortData.FolderPath) -and (!($Update))) {
                         New-Item -Path $sortData.FolderPath -ItemType Directory -Force:$Force | Out-Null

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -132,6 +132,7 @@ function Set-JVMovie {
             $ActressLanguageJa = $Settings.'sort.metadata.nfo.actresslanguageja'
             $OriginalPath = $Settings.'sort.metadata.nfo.originalpath'
             $AltNameRole = $Settings.'sort.metadata.nfo.altnamerole'
+            $AddGenericRole = $Settings.'sort.metadata.nfo.addgenericrole'
             $ScreenshotImgPadding = $Settings.'sort.format.screenshotimg.padding'
             $Proxy = $Settings.'proxy.enabled'
             $ProxyUrl = $Settings.'proxy.host'
@@ -165,9 +166,9 @@ function Set-JVMovie {
         } #>
 
         if ($OriginalPath) {
-            $nfoContents = $Data | Get-JVNfo -NameOrder $FirstNameOrder -ActressLanguageJa:$ActressLanguageJa -OriginalPath:$Path -AltNameRole:$AltNameRole
+            $nfoContents = $Data | Get-JVNfo -NameOrder $FirstNameOrder -ActressLanguageJa:$ActressLanguageJa -OriginalPath:$Path -AltNameRole:$AltNameRole -AddGenericRole:$AddGenericRole
         } else {
-            $nfoContents = $Data | Get-JVNfo -NameOrder $FirstNameOrder -ActressLanguageJa:$ActressLanguageJa -AltNameRole:$AltNameRole
+            $nfoContents = $Data | Get-JVNfo -NameOrder $FirstNameOrder -ActressLanguageJa:$ActressLanguageJa -AltNameRole:$AltNameRole -AddGenericRole:$AddGenericRole
         }
 
         <# if ($MoveToFolder) {

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -1,4 +1,4 @@
-﻿$cache:guiVersion = '2.5.1-0'
+﻿$cache:guiVersion = '2.5.2-0'
 
 # Define Javinizer module file paths
 $cache:modulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -133,6 +133,7 @@ $sortSettings = @(
     'sort.format.groupactress',
     'sort.metadata.nfo.mediainfo',
     'sort.metadata.nfo.altnamerole',
+    'sort.metadata.nfo.addgenericrole',
     'sort.metadata.nfo.firstnameorder',
     'sort.metadata.nfo.actresslanguageja',
     'sort.metadata.nfo.unknownactress',
@@ -3563,6 +3564,7 @@ $Pages += New-UDPage -Name "Settings" -Content {
                                 'sort.format.groupactress' { 'Specifies to convert the format string for <ACTORS> when there is more than one actress to "@Group" and if unknown, to "@Unknown"' }
                                 'sort.metadata.nfo.mediainfo' { 'Specifies to add media metadata information to the nfo file, this requires the MediaInfo command line application' }
                                 'sort.metadata.nfo.altnamerole' { 'Specifies to set the actress role in the nfo as the altname' }
+                                'sort.metadata.nfo.addgenericrole' { 'Specifies to set the actress role in the nfo as Actress' }
                                 'sort.metadata.nfo.firstnameorder' { 'Specifies to set the actress name order to FirstName LastName' }
                                 'sort.metadata.nfo.actresslanguageja' { 'Specifies to prefer Japanese names when creating the metadata nfo' }
                                 'sort.metadata.nfo.unknownactress' { 'Specifies to add an "Unknown" actress to sorted movies without any actresses' }

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -72,6 +72,7 @@
   "sort.format.screenshotfolder": "extrafanart",
   "sort.format.actressimgfolder": ".actors",
   "sort.metadata.nfo.mediainfo": false,
+  "sort.metadata.nfo.addgenericrole": true,
   "sort.metadata.nfo.altnamerole": false,
   "sort.metadata.nfo.translate": false,
   "sort.metadata.nfo.translate.module": "googletrans",


### PR DESCRIPTION
### Added
- Add setting to toggle the addition of generic actress role of `<role>Actress</role>` (#273)
  -   `sort.metadata.nfo.addgenericrole`
### Fixed
- 3 -> 0 retries on webrequest to check for javlibrary cloudflare blocking to speed up initialization
- Fixed json conversion loop which was breaking multiple javinizer GUI components
- Regex multi-part matcher for movies that don't match standard DVD ID format should now match properly
- Duplicate actresses without Japanese name should now be ignored from actress autoadd to thumb csv (again)
