### PR TITLE
2.5.3

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.3]
+
+### Fixed
+- JAVLibrary cloudflare session now properly added to requests when running Javinizer without `-Path` (e.g. using location.input)
+- Suppress errors related to regex partnumber match when no partnumber is present
+
 ## [2.5.2]
 ### Added
 - Add setting to toggle the addition of generic actress role of `<role>Actress</role>` (#273)

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.5.2'
+    ModuleVersion     = '2.5.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -228,7 +228,7 @@ function Convert-JVTitle {
             elseif ($RegexEnabled) {
                 $fileP1, $fileP2 = $fileBaseNameUpper[$x] -split "-pt"
 
-                $filePartNum = ((($fileP2.Trim() -replace '-', '' -replace '\.', '') -replace '^0{1,5}', '') -replace '(cd|part|pt)', '')
+                $filePartNum = ((($fileP2 -replace '-', '' -replace '\.', '') -replace '^0{1,5}', '') -replace '(cd|part|pt)', '')
                 if ($filePartNum -match '^\d+$') {
                     $filePartNumber = [int]$filePartNum
                     $fileBaseNameUpperCleaned += $fileP1

--- a/src/Javinizer/Private/Test-JavlibraryCf.ps1
+++ b/src/Javinizer/Private/Test-JavlibraryCf.ps1
@@ -1,0 +1,56 @@
+
+function Test-JavlibraryCf {
+    param (
+        [PSObject]$Settings,
+        [PSObject]$CfSession
+    )
+
+    $ProgressPreference = 'SilentlyContinue'
+
+    if (!($CfSession)) {
+        try {
+            Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -MaximumRetryCount 0 -Verbose:$false | Out-Null
+        } catch {
+            try {
+                $CfSession = Get-CfSession -cf_chl_2:$Settings.'javlibrary.cookie.cf_chl_2' -cf_chl_prog:$Settings.'javlibrary.cookie.cf_chl_prog' -cf_clearance:$Settings.'javlibrary.cookie.cf_clearance' -UserAgent:$Settings.'javlibrary.browser.useragent' -BaseUrl $Settings.'javlibrary.baseurl'
+                # Testing with the newly created session sometimes fails if there is no wait time
+                Start-Sleep -Seconds 1
+                Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -MaximumRetryCount 0 -Verbose:$false | Out-Null
+            } catch {
+                Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($MyInvocation.MyCommand.Name)] Unable reach Javlibrary, enter JAVLibrary cookies and browser useragent to use the scraper"
+                $CfSession = Get-CfSession -BaseUrl $Settings.'javlibrary.baseurl'
+                # Testing with the newly created session sometimes fails if there is no wait time
+                Start-Sleep -Seconds 1
+                try {
+                    Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -MaximumRetryCount 0 -Verbose:$false | Out-Null
+                    if ($CfSession) {
+                        $originalSettingsContent = Get-Content -Path $SettingsPath
+                        $cookies = $CfSession.Cookies.GetCookies($Settings.'javlibrary.baseurl')
+                        $cf_clearance = ($cookies | Where-Object { $_.Name -eq 'cf_clearance' }).Value
+                        $cf_chl_2 = ($cookies | Where-Object { $_.Name -eq 'cf_chl_2' }).Value
+                        $cf_chl_prog = ($cookies | Where-Object { $_.Name -eq 'cf_chl_prog' }).Value
+                        $userAgent = $CfSession.UserAgent
+                        $settingsContent = $OriginalSettingsContent
+                        $settingsContent = $settingsContent -replace '"javlibrary\.cookie\.cf_chl_2": ".*"', "`"javlibrary.cookie.cf_chl_2`": `"$cf_chl_2`""
+                        $settingsContent = $settingsContent -replace '"javlibrary\.cookie\.cf_chl_prog": ".*"', "`"javlibrary.cookie.cf_chl_prog`": `"$cf_chl_prog`""
+                        $settingsContent = $settingsContent -replace '"javlibrary\.cookie\.cf_clearance": ".*"', "`"javlibrary.cookie.cf_clearance`": `"$cf_clearance`""
+                        $settingsContent = $settingsContent -replace '"javlibrary\.browser\.useragent": ".*"', "`"javlibrary.browser.useragent`": `"$userAgent`""
+
+                        $settingsContent | Out-File -FilePath $SettingsPath
+                        Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Warning -Message "[$($MyInvocation.MyCommand.Name)] Replaced Javlibrary settings with updated values in [$SettingsPath]"
+                    }
+                } catch {
+                    Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Unable reach Javlibrary, invalid websession values"
+                }
+            }
+        }
+    } else {
+        try {
+            Invoke-WebRequest -Uri $Settings.'javlibrary.baseurl' -WebSession $CfSession -UserAgent $CfSession.UserAgent -MaximumRetryCount 0 -Verbose:$false | Out-Null
+        } catch {
+            Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Error -Message "[$($MyInvocation.MyCommand.Name)] Unable reach Javlibrary, invalid websession values"
+        }
+    }
+
+    Write-Output $CfSession
+}

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -1,4 +1,4 @@
-﻿$cache:guiVersion = '2.5.2-0'
+﻿$cache:guiVersion = '2.5.3-0'
 
 # Define Javinizer module file paths
 $cache:modulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation


### PR DESCRIPTION
### Fixed
- JAVLibrary cloudflare session now properly added to requests when running Javinizer without `-Path` (e.g. using location.input)
- Suppress errors related to regex partnumber match when no partnumber is present
