### PR TITLE
2.5.6

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.6]
+
+### Added
+- Timeout configuration for trailer/screenshot download requests (in ms) (#286)
+- CLI docker images (tag: `jvlflame/javinizer:latest-cli)
+
+### Fixed
+- Series metadata for r18 now properly uncensored
+- Actresses with invalid thumburl no longer automatically added to r18 thumb csv (after r18 html changes)
+
 ## [2.5.5]
 
 ### Fixed

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,0 +1,42 @@
+FROM python:3.9.2-buster
+
+# Add docker entrypoint script
+ADD docker-entrypoint-cli.sh /
+RUN chmod +x /docker-entrypoint-cli.sh
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get install -y wget nano
+
+# Create directories
+RUN mkdir -p /home
+
+# Install mediainfo
+RUN apt-get install -y mediainfo
+
+# Install pwsh
+RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y powershell \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pwsh modules
+RUN pwsh -c "Set-PSRepository 'PSGallery' -InstallationPolicy Trusted" \
+    && pwsh -c "Install-Module Javinizer"
+
+# Install python modules
+RUN pip3 install pillow \
+    google_trans_new \
+    googletrans==4.0.0rc1
+
+# Clean up
+#RUN apt-get purge unzip \
+#    wget \
+#    && apt-get autoremove
+
+# Create symlink to module settings file
+RUN pwsh -c "ln -s (Join-Path (Get-InstalledModule Javinizer).InstalledLocation -ChildPath jvSettings.json) /home/jvSettings.json"
+
+EXPOSE 8600
+ENTRYPOINT ["/docker-entrypoint-cli.sh"]

--- a/README.md
+++ b/README.md
@@ -142,9 +142,14 @@ After running `Javinizer -OpenGUI`, the PowerShell Universal process should run 
 #### Docker
 
 ```
+# To run GUI
 docker run --name javinizer -p 8600:8600 -d jvlflame/javinizer:latest
 
+# To run CLI
+docker run --name javinizer -p 8600:8600 -d jvlflame/javinizer:latest-cli
+
 # Optional
+# You will need to copy the jvSettings.json configuration from [here](./src/Javinizer/jvSettings.json) and write it to your path/to/jvSettings.json location
 -v path/to/jvSettings.json:/home/jvSettings.json
 ```
 

--- a/docker-entrypoint-cli.sh
+++ b/docker-entrypoint-cli.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+umask 000
+
+# Start powershell
+set -e
+echo "Starting pwsh"
+exec "$@";
+
+pwsh

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.5.5'
+    ModuleVersion     = '2.5.6'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Scraper.R18.ps1
+++ b/src/Javinizer/Private/Scraper.R18.ps1
@@ -185,9 +185,14 @@ function Get-R18Series {
     )
 
     process {
-
         if ($Webrequest.data.series) {
             $series = $Webrequest.data.series.name
+
+            if ($Replace) {
+                foreach ($string in $Replace.GetEnumerator()) {
+                    $series = $series -replace [regex]::Escape($string.Original), $string.Replacement
+                }
+            }
         } else {
             $series = $null
         }

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -390,7 +390,7 @@ function Get-JVAggregatedData {
                                         Alias        = $null
                                     }
                                     # We only want to write the actress if the thumburl isn't null
-                                    if ($actressObject.ThumbUrl -ne '' -and $null -ne $actressObject.ThumbUrl) {
+                                    if ($actressObject.ThumbUrl -ne '' -and $null -ne $actressObject.ThumbUrl -and $actressObject.ThumbUrl -notlike '*printing*') {
                                         $actressObject | Export-Csv -LiteralPath $ThumbCsvPath -Append
                                         Write-JVLog -Write:$script:JVLogWrite -LogPath $script:JVLogPath -WriteLevel $script:JVLogWriteLevel -Level Info -Message "[$($Data[0].Id)] [$($MyInvocation.MyCommand.Name)] Wrote [$fullName - $($actress.JapaneseName)] to thumb csv"
                                     }

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -1,4 +1,4 @@
-$cache:guiVersion = '2.5.5-1'
+$cache:guiVersion = '2.5.6-1'
 
 # Define Javinizer module file paths
 $cache:modulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -58,6 +58,7 @@
   "sort.download.posterimg": true,
   "sort.download.screenshotimg": false,
   "sort.download.trailervid": false,
+  "sort.download.timeoutduration": 100000,
   "sort.format.groupactress": true,
   "sort.format.delimiter": ", ",
   "sort.format.file": "<ID>",


### PR DESCRIPTION
### Added
- Timeout configuration for trailer/screenshot download requests (in ms) (#286)
- CLI docker images (tag: `jvlflame/javinizer:latest-cli)

### Fixed
- Series metadata for r18 now properly uncensored
- Actresses with invalid thumburl no longer automatically added to r18 thumb csv (after r18 html changes)
