### PR TITLE
2.5.7

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.7]
+
+### Added
+- Setting `sort.metadata.nfo.addaliases` to add all actress aliases alongside the original name as separate actresses in the nfo (#290) (#291)
+
+### Changed
+- Improved filematcher (#289)
+  - contentId matching is now improved
+  - file names starting with `.*\.org@` are now matched properly (e.g. bbs2048.org@MOVIE-123.mp4)
+
+### Fixed
+- Fixed fields on `dmmja` scraper (#293) (#294)
+
 ## [2.5.6]
 
 ### Added

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.6]
+
+### Added
+- Timeout configuration for trailer/screenshot download requests (in ms) (#286)
+- CLI docker images (tag: `jvlflame/javinizer:latest-cli)
+
+### Fixed
+- Series metadata for r18 now properly uncensored
+- Actresses with invalid thumburl no longer automatically added to r18 thumb csv (after r18 html changes)
+
 ## [2.5.5]
 
 ### Fixed

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.5.5'
+    ModuleVersion     = '2.5.6'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Javinizer.psd1
+++ b/src/Javinizer/Javinizer.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.5.6'
+    ModuleVersion     = '2.5.7'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Core')

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -34,6 +34,7 @@ function Convert-JVTitle {
             '[\u3040-\u309f]|[\u30a0-\u30ff]|[\uff66-\uff9f]|[\u4e00-\u9faf]',
             '.*\.com\@',
             '.*\.org\@',
+            '.*\.xyz\-',
             '[@|-|_]?[a-zA-Z0-9]+(\.com|\.net|\.tk)[_|-]?',
             '^_'
             '^[0-9]{4}',
@@ -303,6 +304,8 @@ function Convert-JVTitle {
             # This will require less reliance on using -Strict during commandline usage
             if ($movieId -notmatch '([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)' -and $RegexEnabled -eq $false) {
                 $Strict = $true
+                Write-Host "Strict"
+                Write-Host "Strict"
                 Write-Host "Strict"
                 Write-Host "Strict"
                 Write-Host "Strict"

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -125,10 +125,11 @@ function Convert-JVTitle {
             }
 
             foreach ($file in $FileBaseNameOriginal) {
-                if ($file -match '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d+)') {
+                if ($file -match '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d{3,8})') {
                     # Extract content ID without prefixes if match
                     try {
-                        $file = ($file | Select-String -Pattern '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d{3,8})').Matches.Groups[2].Value
+                        $partNum = ($file | Select-String -Pattern '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d{3,8})(.*)').Matches.Groups[3].Value
+                        $file = ($file | Select-String -Pattern '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d{3,8})').Matches.Groups[2].Value + $partNum
                     } catch {
                         # Don't re-assign if match fails
                     }
@@ -302,6 +303,14 @@ function Convert-JVTitle {
             # This will require less reliance on using -Strict during commandline usage
             if ($movieId -notmatch '([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)' -and $RegexEnabled -eq $false) {
                 $Strict = $true
+                Write-Host "Strict"
+                Write-Host "Strict"
+                Write-Host "Strict"
+                Write-Host "Strict"
+                Write-Host "Strict"
+                Write-Host "Strict"
+                Write-Host "Strict"
+                Write-Host "Strict"
                 Write-Host "Strict"
                 Write-Host "Strict"
                 Write-Host "Strict"

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -33,6 +33,7 @@ function Convert-JVTitle {
             # Prefixes
             '[\u3040-\u309f]|[\u30a0-\u30ff]|[\uff66-\uff9f]|[\u4e00-\u9faf]',
             '.*\.com\@',
+            '.*\.org\@',
             '[@|-|_]?[a-zA-Z0-9]+(\.com|\.net|\.tk)[_|-]?',
             '^_'
             '^[0-9]{4}',
@@ -127,7 +128,7 @@ function Convert-JVTitle {
                 if ($file -match '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d+)') {
                     # Extract content ID without prefixes if match
                     try {
-                        $file = ($file | Select-String -Pattern '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d+)').Matches.Groups[2].Value
+                        $file = ($file | Select-String -Pattern '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d{3,8})').Matches.Groups[2].Value
                     } catch {
                         # Don't re-assign if match fails
                     }
@@ -301,6 +302,8 @@ function Convert-JVTitle {
             # This will require less reliance on using -Strict during commandline usage
             if ($movieId -notmatch '([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)' -and $RegexEnabled -eq $false) {
                 $Strict = $true
+                Write-Host "Strict"
+                Write-Host "Strict"
                 Write-Host "Strict"
                 Write-Host "Strict"
                 Write-Host "Strict"

--- a/src/Javinizer/Private/Convert-JVTitle.ps1
+++ b/src/Javinizer/Private/Convert-JVTitle.ps1
@@ -124,6 +124,14 @@ function Convert-JVTitle {
             }
 
             foreach ($file in $FileBaseNameOriginal) {
+                if ($file -match '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d+)') {
+                    # Extract content ID without prefixes if match
+                    try {
+                        $file = ($file | Select-String -Pattern '([a-zA-Z]?_?\d+)?([a-zA-Z]+\d+)').Matches.Groups[2].Value
+                    } catch {
+                        # Don't re-assign if match fails
+                    }
+                }
                 $fileBaseNameUpper += $file.ToUpper()
             }
 
@@ -293,6 +301,9 @@ function Convert-JVTitle {
             # This will require less reliance on using -Strict during commandline usage
             if ($movieId -notmatch '([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)' -and $RegexEnabled -eq $false) {
                 $Strict = $true
+                Write-Host "Strict"
+                Write-Host "Strict"
+                Write-Host "Strict"
             }
 
             if ($Strict.IsPresent) {

--- a/src/Javinizer/Private/Scraper.Dmm.ps1
+++ b/src/Javinizer/Private/Scraper.Dmm.ps1
@@ -136,7 +136,7 @@ function Get-DmmDirector {
 
     process {
         try {
-            $director = ($Webrequest.Content | Select-String -Pattern '\/article=director\/id=\d*\/">(.*)<\/a>').Matches.Groups[1].Value
+            $director = ($Webrequest.Content | Select-String -Pattern '\/article=director\/id=\d*\/"[^>]*?>(.*)<\/a>').Matches.Groups[1].Value
         } catch {
             return
         }
@@ -152,7 +152,7 @@ function Get-DmmMaker {
 
     process {
         try {
-            $maker = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=maker\/id=\d*\/">(.*)<\/a>').Matches.Groups[2].Value
+            $maker = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=maker\/id=\d*\/"[^>]*?>(.*)<\/a>').Matches.Groups[2].Value
         } catch {
             return
         }
@@ -168,7 +168,7 @@ function Get-DmmLabel {
 
     process {
         try {
-            $label = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=label\/id=\d*\/">(.*)<\/a>').Matches.Groups[2].Value
+            $label = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=label\/id=\d*\/"[^>]*?>(.*)<\/a>').Matches.Groups[2].Value
         } catch {
             return
         }
@@ -184,7 +184,7 @@ function Get-DmmSeries {
 
     process {
         try {
-            $series = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=series\/id=\d*\/">(.*)<\/a><\/td>').Matches.Groups[2].Value
+            $series = ($Webrequest.Content | Select-String -Pattern '<a href="(\/digital\/videoa\/|(?:\/en)?\/mono\/dvd\/)-\/list\/=\/article=series\/id=\d*\/"[^>]*?>(.*)<\/a><\/td>').Matches.Groups[2].Value
         } catch {
             return
         }

--- a/src/Javinizer/Public/Get-JVNfo.ps1
+++ b/src/Javinizer/Public/Get-JVNfo.ps1
@@ -180,9 +180,9 @@ function Get-JVNfo {
         }
 
         foreach ($item in $Actress) {
-            $actressName = $null
+            $actors = @()
+            $actressNfoString = ''
             if ($ActressLanguageJa) {
-                $actors = @()
                 if ($null -ne $item.JapaneseName -and $item.JapaneseName -ne '') {
                     $actors += [PSCustomObject]@{
                         Name     = $item.JapaneseName
@@ -238,7 +238,6 @@ function Get-JVNfo {
                     }
                 }
             } else {
-                $actors = @()
                 if (($null -ne $item.FirstName -and $item.FirstName -ne '') -or ($null -ne $item.LastName -and $item.LastName -ne '')) {
                     if ($NameOrder) {
                         $actors += [PSCustomObject]@{
@@ -273,9 +272,12 @@ function Get-JVNfo {
                     }
                 }
 
-                if ($null -eq $actressName) {
+                if ($actors.Length -eq 0) {
                     if ($null -ne $item.JapaneseName) {
-                        $actressName = ($item.JapaneseName).Trim()
+                        $actors += [PSCustomObject]@{
+                            Name     = $item.JapaneseName
+                            ThumbUrl = $item.ThumbUrl
+                        }
                     }
                     $altName = $null
                 }

--- a/src/Javinizer/Public/Javinizer.ps1
+++ b/src/Javinizer/Public/Javinizer.ps1
@@ -770,7 +770,7 @@ function Javinizer {
                 }
 
                 if ($Nfo) {
-                    $nfoData = $data.Data | Get-JVNfo -ActressLanguageJa:$Settings.'sort.metadata.nfo.actresslanguageja' -NameOrder:$Settings.'sort.metadata.nfo.firstnameorder' -AltNameRole:$Settings.'sort.metadata.nfo.altnamerole' -AddGenericRole:$Settings.'sort.metadata.nfo.addgenericrole'
+                    $nfoData = $data.Data | Get-JVNfo -ActressLanguageJa:$Settings.'sort.metadata.nfo.actresslanguageja' -NameOrder:$Settings.'sort.metadata.nfo.firstnameorder' -AltNameRole:$Settings.'sort.metadata.nfo.altnamerole' -AddGenericRole:$Settings.'sort.metadata.nfo.addgenericrole' -AddAliases:$Settings.'sort.metadata.nfo.addaliases'
                     Write-Output $nfoData
                 } elseif ($Search -and $Aggregated) {
                     [PSCustomObject]@{

--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -193,9 +193,9 @@ public class ExtendedWebClient : WebClient {
         } #>
 
         if ($OriginalPath) {
-            $nfoContents = $Data | Get-JVNfo -NameOrder $FirstNameOrder -ActressLanguageJa:$ActressLanguageJa -OriginalPath:$Path -AltNameRole:$AltNameRole -AddGenericRole:$AddGenericRole
+            $nfoContents = $Data | Get-JVNfo -NameOrder $FirstNameOrder -ActressLanguageJa:$ActressLanguageJa -OriginalPath:$Path -AltNameRole:$AltNameRole -AddGenericRole:$AddGenericRole -AddAliases:$Settings.'sort.metadata.nfo.addaliases'
         } else {
-            $nfoContents = $Data | Get-JVNfo -NameOrder $FirstNameOrder -ActressLanguageJa:$ActressLanguageJa -AltNameRole:$AltNameRole -AddGenericRole:$AddGenericRole
+            $nfoContents = $Data | Get-JVNfo -NameOrder $FirstNameOrder -ActressLanguageJa:$ActressLanguageJa -AltNameRole:$AltNameRole -AddGenericRole:$AddGenericRole -AddAliases:$Settings.'sort.metadata.nfo.addaliases'
         }
 
         <# if ($MoveToFolder) {

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -1,4 +1,4 @@
-$cache:guiVersion = '2.5.6-1'
+$cache:guiVersion = '2.5.7-1'
 
 # Define Javinizer module file paths
 $cache:modulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation

--- a/src/Javinizer/Universal/Repository/javinizergui.ps1
+++ b/src/Javinizer/Universal/Repository/javinizergui.ps1
@@ -1,4 +1,4 @@
-$cache:guiVersion = '2.5.5-1'
+$cache:guiVersion = '2.5.6-1'
 
 # Define Javinizer module file paths
 $cache:modulePath = (Get-InstalledModule -Name Javinizer).InstalledLocation

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -72,6 +72,7 @@
   "sort.format.screenshotimg.padding": 1,
   "sort.format.screenshotfolder": "extrafanart",
   "sort.format.actressimgfolder": ".actors",
+  "sort.metadata.nfo.addaliases": false,
   "sort.metadata.nfo.mediainfo": false,
   "sort.metadata.nfo.addgenericrole": true,
   "sort.metadata.nfo.altnamerole": false,


### PR DESCRIPTION
### Added
- Setting `sort.metadata.nfo.addaliases` to add all actress aliases alongside the original name as separate actresses in the nfo (#290) (#291)

### Changed
- Improved filematcher (#289)
  - contentId matching is now improved
  - file names starting with `.*\.org@` are now matched properly (e.g. bbs2048.org@MOVIE-123.mp4)
  - file names starting with `.*\.xyz-` are now matched properly (e.g. aaxv.xyz-MOVIE-123.mp4)

### Fixed
- Fixed fields on `dmmja` scraper (#293) (#294)