### PR TITLE
disable error SYSLIB0014

### DIFF
--- a/src/Javinizer/Public/Set-JVMovie.ps1
+++ b/src/Javinizer/Public/Set-JVMovie.ps1
@@ -94,6 +94,7 @@ function Set-JVMovie {
         # Add custom webclient class to extend timeout durations
         # https://stackoverflow.com/questions/40431173/powershell-script-webclient-timeout-140-calling-an-ssrs-report
         $Source = @"
+#pragma warning disable SYSLIB0014
 using System.Net;
 
 public class ExtendedWebClient : WebClient {


### PR DESCRIPTION
disable error SYSLIB0014
## Description
disable error SYSLIB0014
Because it will error in PowerShell 7
```
 (14,5): error SYSLIB0014: “WebClient.WebClient()”已过时:“WebRequest, HttpWebRequest, ServicePoint, and
     | WebClient are obsolete. Use HttpClient instead.”     public ExtendedWebClient() {     ^
```