### PR TITLE
Add Deepl support for translate

### DIFF
--- a/src/Javinizer/Private/Get-TranslatedString.ps1
+++ b/src/Javinizer/Private/Get-TranslatedString.ps1
@@ -7,15 +7,19 @@ function Get-TranslatedString {
 
         [String]$Language = 'en',
 
-        [ValidateSet('googletrans', 'google_trans_new')]
+        [String]$TranslateDeeplApiKey,
+        
+        [ValidateSet('googletrans', 'google_trans_new', 'deepl')]
         [String]$Module
     )
 
     process {
         if ($Module -eq 'google_trans_new') {
             $translatePath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'translate_new.py'
-        } else {
+        } elseif($Module -eq 'googletrans') {
             $translatePath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'translate.py'
+        } else{
+            $translatePath = Join-Path -Path ((Get-Item $PSScriptRoot).Parent) -ChildPath 'translate_deepl.py'
         }
 
         if ($Language -eq 'en') {
@@ -23,9 +27,9 @@ function Get-TranslatedString {
                 if ($null -ne $String -and $String -ne '') {
                     try {
                         if ([System.Environment]::OSVersion.Platform -eq 'Win32NT') {
-                            $tempFile = python $translatePath $String $Language
+                            $tempFile = python $translatePath $String $Language $TranslateDeeplApiKey
                         } elseif ([System.Environment]::OSVersion.Platform -eq 'Unix') {
-                            $tempFile = python3 $translatePath $String $Language
+                            $tempFile = python3 $translatePath $String $Language $TranslateDeeplApiKey
                         }
                         $translatedString = Get-Content -Path $tempFile -Encoding utf8 -Raw
                     } finally {
@@ -39,9 +43,9 @@ function Get-TranslatedString {
             if ($null -ne $String -and $String -ne '') {
                 try {
                     if ([System.Environment]::OSVersion.Platform -eq 'Win32NT') {
-                        $tempFile = python $translatePath $String $Language
+                        $tempFile = python $translatePath $String $Language $TranslateDeeplApiKey
                     } elseif ([System.Environment]::OSVersion.Platform -eq 'Unix') {
-                        $tempFile = python3 $translatePath $String $Language
+                        $tempFile = python3 $translatePath $String $Language $TranslateDeeplApiKey
                     }
                     $translatedString = Get-Content -Path $tempFile -Encoding utf8 -Raw
                 } finally {

--- a/src/Javinizer/Private/Test-JVSettings.ps1
+++ b/src/Javinizer/Private/Test-JVSettings.ps1
@@ -135,6 +135,7 @@ function Test-JVSettings {
             'sort.metadata.nfo.displayname',
             'sort.metadata.nfo.format.tagline',
             'sort.metadata.nfo.translate.language'
+            'sort.metadata.nfo.translate.deeplapikey'
         ) | Test-JVSettingsGroup -Settings $Settings -Type String
 
         $arraySettings = @(

--- a/src/Javinizer/Public/Get-JVAggregatedData.ps1
+++ b/src/Javinizer/Public/Get-JVAggregatedData.ps1
@@ -132,6 +132,10 @@ function Get-JVAggregatedData {
         [String]$TranslateLanguage,
 
         [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
+        [Alias('sort.metadata.nfo.translate.deeplapikey')]
+        [String]$TranslateDeeplApiKey,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Setting')]
         [Alias('sort.metadata.nfo.translate.keeporiginaldescription')]
         [Boolean]$KeepOriginalDescription,
 
@@ -229,6 +233,7 @@ function Get-JVAggregatedData {
             $Translate = $Settings.'sort.metadata.nfo.translate'
             $TranslateFields = $Settings.'sort.metadata.nfo.translate.field'
             $TranslateLanguage = $Settings.'sort.metadata.nfo.translate.language'
+            $TranslateDeeplApiKey = $Settings.'sort.metadata.nfo.translate.deeplapikey'
             $KeepOriginalDescription = $Settings.'sort.metadata.nfo.translate.keeporiginaldescription'
             $DelimiterFormat = $Settings.'sort.format.delimiter'
             $ActressLanguageJa = $Settings.'sort.metadata.nfo.actresslanguageja'
@@ -715,14 +720,14 @@ function Get-JVAggregatedData {
                 $translatedObject.PSObject.Properties | ForEach-Object {
                     if ($_.Name -in $TranslateFields) {
                         if ($_.Name -eq 'Genre') {
-                            $_.Value = Get-TranslatedString -String ($aggregatedDataObject."$($_.Name)" -join '|') -Language $TranslateLanguage -Module $TranslateModule
+                            $_.Value = Get-TranslatedString -String ($aggregatedDataObject."$($_.Name)" -join '|') -Language $TranslateLanguage -Module $TranslateModule -TranslateDeeplApiKey $TranslateDeeplApiKey
                             $genres = @()
                             $rawGenres = $_.Value -split '\|'
                             foreach ($genre in $rawGenres) {
                                 $genres += ($genre).Trim()
                             }
                         } else {
-                            $_.Value = Get-TranslatedString -String $aggregatedDataObject."$($_.Name)" -Language $TranslateLanguage -Module $TranslateModule
+                            $_.Value = Get-TranslatedString -String $aggregatedDataObject."$($_.Name)" -Language $TranslateLanguage -Module $TranslateModule -TranslateDeeplApiKey $TranslateDeeplApiKey
                         }
                         if ($null -ne $_.Value -and ($_.Value).Trim() -ne '') {
                             if ($_.Name -eq 'Genre') {

--- a/src/Javinizer/jvSettings.json
+++ b/src/Javinizer/jvSettings.json
@@ -80,6 +80,7 @@
   "sort.metadata.nfo.translate.module": "googletrans",
   "sort.metadata.nfo.translate.field": "description",
   "sort.metadata.nfo.translate.language": "en",
+  "sort.metadata.nfo.translate.deeplapikey": "",
   "sort.metadata.nfo.translate.keeporiginaldescription": false,
   "sort.metadata.nfo.displayname": "[<ID>] <TITLE>",
   "sort.metadata.nfo.firstnameorder": false,

--- a/src/Javinizer/translate_deepl.py
+++ b/src/Javinizer/translate_deepl.py
@@ -1,0 +1,23 @@
+import sys
+import requests
+import tempfile
+import os
+import json
+
+#Select Url based on key provided (free keys always end in :fx)
+baseurl = "https://api-free.deepl.com/v2/translate" if sys.argv[3].endswith(":fx") else "https://api.deepl.com/v2/translate"
+
+url = "{}?auth_key={}&text={}&target_lang={}".format(baseurl, sys.argv[3], sys.argv[1], sys.argv[2])
+r = requests.get(url)
+j = json.loads(r.text)
+n = j['translations'][0]['text']
+
+text = n.encode('utf8')
+
+# Write the translated text to a temporary file to bypass encoding issues when redirecting the text to PowerShell
+new_file, filename = tempfile.mkstemp()
+os.write(new_file, text)
+os.close(new_file)
+
+# Return the path to the temporary file to read it from PowerShell
+print(filename)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds [DeepL](https://www.deepl.com/translator) support for the plot translation.
in order to use it you need to provide an ApiKey which can be obtained here: https://www.deepl.com/pro-api?cta=header-pro
(With the free ApiKey you can translate up to 500.000 characters free of charge (CreditCard required for sign up)

Currently the ApiKey will not be validated on used as is.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
DeepL offers better and more natrual translations than googletranslate
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Windows Server 2019 with pwsh 7.1.3 and python 3.8.5 with a free ApiKey


